### PR TITLE
feat: add .zip as supported wsi file extension

### DIFF
--- a/src/aignostics/application/_service.py
+++ b/src/aignostics/application/_service.py
@@ -631,6 +631,8 @@ class Service(BaseService):
                                     if row["reference"].lower().endswith((".tif", ".tiff"))
                                     else "application/dicom"
                                     if row["reference"].lower().endswith(".dcm")
+                                    else "application/zip"
+                                    if row["reference"].lower().endswith(".zip")
                                     else "application/octet-stream"
                                 ),
                                 "resolution_mpp": float(row["resolution_mpp"]),

--- a/src/aignostics/constants.py
+++ b/src/aignostics/constants.py
@@ -11,4 +11,4 @@ NOTEBOOK_DEFAULT = Path(__file__).parent / "notebook" / "_notebook.py"
 # Project specific configuration
 os.environ["MATPLOTLIB"] = "false"
 os.environ["NICEGUI_STORAGE_PATH"] = str(Path.home().resolve() / ".aignostics" / ".nicegui")
-WSI_SUPPORTED_FILE_EXTENSIONS = {".dcm", ".tiff", ".tif", ".svs"}
+WSI_SUPPORTED_FILE_EXTENSIONS = {".dcm", ".tiff", ".tif", ".svs", ".zip"}

--- a/src/aignostics/qupath/scripts/add.groovy
+++ b/src/aignostics/qupath/scripts/add.groovy
@@ -91,7 +91,7 @@ try {
     
     // Define supported file extensions (matching WSI_SUPPORTED_FILE_EXTENSIONS from Python)
     def supportedExtensions = [
-        ".dcm", ".svs", ".tif", ".tiff"
+        ".dcm", ".svs", ".tif", ".tiff", ".zip"
     ] as Set
     
     // Helper function to check if file is supported


### PR DESCRIPTION
We support [zipped dicom file-sets](https://dicom.nema.org/medical/dicom/current/output/chtml/part12/chapter_v.html) in the Atlas H&E TME application. Some follow-ups we could should consider to the proposed changes here:
* validate the zip file before sending it, e.g. check whether it contains dicom files
* add [thumbnail support](https://github.com/aignostics/python-sdk/blob/0194e85ea7fcdce182f7698125f0965cf2691ebd/src/aignostics/wsi/_service.py#L39) for zipped dicoms

@helmut-hoffer-von-ankershoffen Should any of the points be done in this MR?