### PR TITLE
chore(gha): add metadata to BetterStack when posting heartbeats

### DIFF
--- a/.github/workflows/_scheduled-audit.yml
+++ b/.github/workflows/_scheduled-audit.yml
@@ -90,11 +90,13 @@ jobs:
               }'
             )
 
-            curl "${BETTERSTACK_AUDIT_HEARTBEAT_URL}/${EXIT_CODE}" \
+            curl \
+              --fail-with-body \
               --silent \
               --request POST \
               --header "Content-Type: application/json" \
-              --data-binary "${BETTERSTACK_METADATA_PAYLOAD}"
+              --data-binary "${BETTERSTACK_METADATA_PAYLOAD}" \
+              "${BETTERSTACK_AUDIT_HEARTBEAT_URL}/${EXIT_CODE}"
           fi
           exit $EXIT_CODE
 

--- a/.github/workflows/_scheduled-test.yml
+++ b/.github/workflows/_scheduled-test.yml
@@ -113,11 +113,13 @@ jobs:
               }'
             )
 
-            curl "${BETTERSTACK_HEARTBEAT_URL}/${EXIT_CODE}" \
+            curl \
+              --fail-with-body \
               --silent \
               --request POST \
               --header "Content-Type: application/json" \
-              --data-binary "${BETTERSTACK_METADATA_PAYLOAD}"
+              --data-binary "${BETTERSTACK_METADATA_PAYLOAD}" \
+              "${BETTERSTACK_HEARTBEAT_URL}/${EXIT_CODE}"
           fi
           exit $EXIT_CODE
 


### PR DESCRIPTION
This will add metadata like described in: https://betterstack.com/docs/uptime/cron-and-heartbeat-monitor/#reporting-failures

(side note, returning the status code of 0 to betterstack also resolves the incident so we don't need to add a branching statement.

This is useful for responders to quickly see what GitHub run triggered the issue. The following picture shows an example output:

<img width="1308" height="798" alt="image" src="https://github.com/user-attachments/assets/21b9594b-b347-4846-bf8c-4d6bf9a2680b" />
