### PR TITLE
fix: edit profile button opens in browser

### DIFF
--- a/src/aignostics/gui/_frame.py
+++ b/src/aignostics/gui/_frame.py
@@ -3,6 +3,7 @@
 import contextlib
 import platform
 import sys
+import webbrowser
 from collections.abc import Generator
 from contextlib import contextmanager
 from importlib.util import find_spec
@@ -19,8 +20,6 @@ FLAT_COLOR_WHITE = "flat color=white"
 
 HEALTH_UPDATE_INTERVAL = 30
 USERINFO_UPDATE_INTERVAL = 60 * 60
-
-PROFILE_EDIT_URL = "https://platform.aignostics.com/dashboard/account/profile"
 
 
 @contextmanager
@@ -46,7 +45,7 @@ def frame(  # noqa: C901, PLR0915
     from nicegui import app, background_tasks, context, run, ui  # noqa: PLC0415
 
     from aignostics.platform import Service as PlatformService  # noqa: PLC0415
-    from aignostics.platform import UserInfo  # noqa: PLC0415
+    from aignostics.platform import UserInfo, settings  # noqa: PLC0415
     from aignostics.system import Service as SystemService  # noqa: PLC0415
 
     theme()
@@ -84,7 +83,7 @@ def frame(  # noqa: C901, PLR0915
                     ui.button(
                         "Edit Profile",
                         icon="edit",
-                        on_click=lambda _: ui.navigate.to(PROFILE_EDIT_URL, new_tab=True),
+                        on_click=lambda: webbrowser.open(settings().profile_edit_url),
                     )
 
     async def _user_info_ui_load() -> None:

--- a/src/aignostics/platform/_settings.py
+++ b/src/aignostics/platform/_settings.py
@@ -225,6 +225,16 @@ class Settings(OpaqueSettings):
             )
             return self.authorization_base_url.rsplit("/", 1)[0] + "/"
 
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def profile_edit_url(self) -> str:
+        """Get the profile edit URL based on the API root.
+
+        Returns:
+            str: Full URL to the profile editor page
+        """
+        return f"{self.api_root}/dashboard/account/profile"
+
     token_url: Annotated[str, BeforeValidator(_validate_url), Field(description="OAuth token endpoint URL")]
     redirect_uri: Annotated[
         str, BeforeValidator(_validate_url), Field(description="OAuth redirect URI for authorization code flow")

--- a/tests/aignostics/platform/settings_test.py
+++ b/tests/aignostics/platform/settings_test.py
@@ -315,6 +315,39 @@ def test_issuer_computed_field_dev(record_property, mock_env_vars) -> None:
 
 
 @pytest.mark.unit
+def test_profile_edit_url_computed_field_production(record_property, mock_env_vars) -> None:
+    """Test profile_edit_url computed field with production API root."""
+    record_property("tested-item-id", "SPEC-PLATFORM-SERVICE")
+    settings = Settings(
+        api_root=API_ROOT_PRODUCTION,
+    )
+    expected_url = f"{API_ROOT_PRODUCTION}/dashboard/account/profile"
+    assert settings.profile_edit_url == expected_url
+
+
+@pytest.mark.unit
+def test_profile_edit_url_computed_field_staging(record_property, mock_env_vars) -> None:
+    """Test profile_edit_url computed field with staging API root."""
+    record_property("tested-item-id", "SPEC-PLATFORM-SERVICE")
+    settings = Settings(
+        api_root=API_ROOT_STAGING,
+    )
+    expected_url = f"{API_ROOT_STAGING}/dashboard/account/profile"
+    assert settings.profile_edit_url == expected_url
+
+
+@pytest.mark.unit
+def test_profile_edit_url_computed_field_dev(record_property, mock_env_vars) -> None:
+    """Test profile_edit_url computed field with dev API root."""
+    record_property("tested-item-id", "SPEC-PLATFORM-SERVICE")
+    settings = Settings(
+        api_root=API_ROOT_DEV,
+    )
+    expected_url = f"{API_ROOT_DEV}/dashboard/account/profile"
+    assert settings.profile_edit_url == expected_url
+
+
+@pytest.mark.unit
 def test_issuer_computed_field_custom_url(record_property, mock_env_vars) -> None:
     """Test issuer computed field with custom authorization base URL."""
     record_property("tested-item-id", "SPEC-PLATFORM-SERVICE")


### PR DESCRIPTION
Currently the button does nothing. After this fix, the button opens a new window (or tab) in the default browser.

Also updating the edit profile URL to depend on `api_root` so users are directed to the correct base URL.