### PR TITLE
test: disable flaky GUI tests on macos-latest and python 3.13

### DIFF
--- a/tests/aignostics/application/gui_test.py
+++ b/tests/aignostics/application/gui_test.py
@@ -1,6 +1,8 @@
 """Tests to verify the GUI functionality of the application module."""
 
+import platform
 import re
+import sys
 import tempfile
 from asyncio import sleep
 from datetime import UTC, datetime, timedelta
@@ -29,6 +31,10 @@ if TYPE_CHECKING:
 
 
 @pytest.mark.e2e
+@pytest.mark.skipif(
+    platform.system() == "Darwin" and platform.machine() == "arm64" and sys.version_info >= (3, 13),
+    reason="GUI tests unstable on macOS Apple Silicon with Python 3.13 (GitHub Actions runner architecture issues)",
+)
 @pytest.mark.flaky(retries=2, delay=5, only_on=[AssertionError])
 @pytest.mark.timeout(timeout=30)
 async def test_gui_index(user: User, silent_logging, record_property) -> None:
@@ -41,6 +47,10 @@ async def test_gui_index(user: User, silent_logging, record_property) -> None:
 
 
 @pytest.mark.e2e
+@pytest.mark.skipif(
+    platform.system() == "Darwin" and platform.machine() == "arm64" and sys.version_info >= (3, 13),
+    reason="GUI tests unstable on macOS Apple Silicon with Python 3.13 (GitHub Actions runner architecture issues)",
+)
 @pytest.mark.flaky(retries=2, delay=5, only_on=[AssertionError])
 @pytest.mark.timeout(timeout=60 * 2)
 @pytest.mark.parametrize(


### PR DESCRIPTION
These tests fail consistently on the `macos-latest` runner with Python 3.13. Skipping for the time being.