### PR TITLE
fix: paginate run results

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ If you want to execute and verify code yourself:
 * Use `uv run pytest ...` to run tests.
 * Use `uv run aignostics ...` to run the CLI and commands.
 * Use `make lint` to check code style and types.
+* Use `make lint_fix` to automatically fix code style issues.
 * Use `make test_unit` to run the unit test suite.
 * Use `make test_integration` to run the integration test suite.
 * Use `make test_e2e` to run the end-to-end (e2e) test suite.

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ $(error Python version validation failed. See error message above.)
 endif
 
 # Define all PHONY targets
-.PHONY: act all audit bump clean codegen dist dist_native docs docker_build gui_watch install lint pre_commit_run_all profile setup test test_coverage_reset test_default test_e2e test_e2e_matrix test_integration test_integration_matrix test_long_running test_scheduled test_stress test_sequential test_unit test_unit_matrix test_very_long_running update_from_template
+.PHONY: act all audit bump clean codegen dist dist_native docs docker_build gui_watch install lint lint_fix pre_commit_run_all profile setup test test_coverage_reset test_default test_e2e test_e2e_matrix test_integration test_integration_matrix test_long_running test_scheduled test_stress test_sequential test_unit test_unit_matrix test_very_long_running update_from_template
 
 
 # Main target i.e. default sessions defined in noxfile.py
@@ -47,7 +47,7 @@ else \
 fi
 
 ## Individual Nox sessions
-act audit bump dist docs lint setup test update_from_template:
+act audit bump dist docs lint lint_fix setup test update_from_template:
 	$(nox-cmd)
 
 # Standalone targets

--- a/noxfile.py
+++ b/noxfile.py
@@ -128,6 +128,18 @@ def lint(session: nox.Session) -> None:
 
 
 @nox.session(python=[PYTHON_VERSION])
+def lint_fix(session: nox.Session) -> None:
+    """Apply code formatting checks and linting."""
+    _setup_venv(session, True)
+    session.run("ruff", "check", "--fix", ".")
+    session.run(
+        "ruff",
+        "format",
+        ".",
+    )
+
+
+@nox.session(python=[PYTHON_VERSION])
 def audit(session: nox.Session) -> None:
     """Run security audit and license checks."""
     _setup_venv(session)

--- a/src/aignostics/application/_gui/_page_application_run_describe.py
+++ b/src/aignostics/application/_gui/_page_application_run_describe.py
@@ -832,49 +832,55 @@ async def _page_application_run_describe(run_id: str) -> None:  # noqa: C901, PL
             for item in displayed_results:
                 await render_item(item)
 
-        # Create "Show more" button container
-        show_more_container = ui.row().classes("w-full justify-center mt-4")
-
-        async def load_more() -> None:
-            """Load and render the next batch of results."""
-            nonlocal has_more_results
-            show_more_button.disable()
-            show_more_button.props(add="loading")
-
-            # Fetch next batch
-            next_batch = await nicegui_run.io_bound(fetch_next_batch)
-            displayed_results.extend(next_batch)
-
-            # Render new items
-            with results_list:
-                for item in next_batch:
-                    await render_item(item)
-
-            show_more_button.props(remove="loading")
-
-            # Hide button if no more results or remaining count is 0
-            remaining = run_data.statistics.item_count - len(displayed_results)
-            if not has_more_results or remaining <= 0:
-                show_more_container.set_visibility(False)
-            else:
-                show_more_button.enable()
-                # Update button text with count
-                show_more_button.text = f"Show more ({remaining} remaining)"
-
-        # Add "Show more" button
-        with show_more_container:
-            remaining = run_data.statistics.item_count - len(displayed_results)
-            show_more_button = (
-                ui.button(
-                    f"Show more ({remaining} remaining)",
-                    icon="expand_more",
-                    on_click=load_more,
-                )
-                .props("outline")
-                .mark("BUTTON_SHOW_MORE_RESULTS")
-            )
-
-        # Hide button if all results are already loaded or remaining count is 0
+        # Calculate if we need pagination before creating UI elements
         remaining_initial = run_data.statistics.item_count - len(displayed_results)
-        if not has_more_results or remaining_initial <= 0:
-            show_more_container.set_visibility(False)
+        needs_pagination = has_more_results and remaining_initial > 0
+
+        # Only create "Show more" button if there are more results to load
+        show_more_container: ui.row | None = None
+        show_more_button: ui.button | None = None
+
+        if needs_pagination:
+            show_more_container = ui.row().classes("w-full justify-center mt-4")
+
+            async def load_more() -> None:
+                """Load and render the next batch of results."""
+                nonlocal has_more_results
+                # These are guaranteed to be set since load_more is only defined when needs_pagination is True
+                if show_more_button is None or show_more_container is None:
+                    return  # Should never happen, but satisfies type checker
+
+                show_more_button.disable()
+                show_more_button.props(add="loading")
+
+                # Fetch next batch
+                next_batch = await nicegui_run.io_bound(fetch_next_batch)
+                displayed_results.extend(next_batch)
+
+                # Render new items
+                with results_list:
+                    for item in next_batch:
+                        await render_item(item)
+
+                show_more_button.props(remove="loading")
+
+                # Hide button if no more results or remaining count is 0
+                remaining = run_data.statistics.item_count - len(displayed_results)
+                if not has_more_results or remaining <= 0:
+                    show_more_container.set_visibility(False)
+                else:
+                    show_more_button.enable()
+                    # Update button text with count
+                    show_more_button.text = f"Show more ({remaining} remaining)"
+
+            # Add "Show more" button
+            with show_more_container:
+                show_more_button = (
+                    ui.button(
+                        f"Show more ({remaining_initial} remaining)",
+                        icon="expand_more",
+                        on_click=load_more,
+                    )
+                    .props("outline")
+                    .mark("BUTTON_SHOW_MORE_RESULTS")
+                )

--- a/src/aignostics/application/_gui/_page_application_run_describe.py
+++ b/src/aignostics/application/_gui/_page_application_run_describe.py
@@ -16,7 +16,7 @@ from nicegui import (
 )
 from nicegui import run as nicegui_run
 
-from aignostics.platform import ItemOutput, ItemState, RunState
+from aignostics.platform import ItemOutput, ItemResult, ItemState, RunState
 from aignostics.third_party.showinfm.showinfm import show_in_file_manager
 from aignostics.utils import GUILocalFilePicker, get_user_data_directory
 
@@ -34,6 +34,7 @@ from ._utils import (
 )
 
 WIDTH_1200px = "width: 1200px; max-width: none"
+RESULTS_PAGE_SIZE = 20
 
 service = Service()
 
@@ -648,156 +649,232 @@ async def _page_application_run_describe(run_id: str) -> None:  # noqa: C901, PL
                         on_click=lambda t=tag: ui.navigate.to(f"/?query={quote(str(t))}"),
                     ).props("small outlined clickable").classes("bg-white text-black")
 
-        with ui.list().classes("full-width"):
-            results = list(run.results())
-            if not results:
-                with ui.row().classes("w-full justify-center content-center"):
-                    ui.space()
-                    ui.html(
-                        '<dotlottie-player src="/application_assets/empty.lottie" '
-                        'background="transparent" speed="1" style="width: 700px; height: 700px" '
-                        'direction="1" playMode="normal" loop autoplay></dotlottie-player>',
-                        sanitize=False,
+        # Pagination state
+        results_iterator = run.results()
+        displayed_results: list[ItemResult] = []
+        has_more_results = True
+
+        async def render_item(item: ItemResult) -> None:  # noqa: C901, PLR0912, PLR0915
+            """Render a single result item."""
+            with ui.item().classes("h-96 px-0").props("clickable"):
+                with (
+                    ui.item_section().classes("h-full"),
+                    ui.card().tight().classes("h-full"),
+                    ui.row().classes("w-full"),
+                ):
+                    image_file: AsyncPath | None = await AsyncPath(item.external_id).resolve()
+                    if image_file and await image_file.is_file():
+                        image_url = "/thumbnail?source=" + quote(image_file.as_posix())
+                    else:
+                        image_file = None
+                        image_url = "/application_assets/image-not-found.png"
+                    ui.image(image_url).classes("object-contain absolute-center max-h-full")
+                    icon, color = run_item_status_and_termination_reason_to_icon_and_color(
+                        item.state.value, item.termination_reason
                     )
-                    ui.space()
-                return
-            for item in results:
-                with ui.item().classes("h-96 px-0").props("clickable"):
-                    with (
-                        ui.item_section().classes("h-full"),
-                        ui.card().tight().classes("h-full"),
-                        ui.row().classes("w-full"),
-                    ):
-                        image_file: AsyncPath | None = await AsyncPath(item.external_id).resolve()
-                        if image_file and await image_file.is_file():
-                            image_url = "/thumbnail?source=" + quote(image_file.as_posix())
-                        else:
-                            image_file = None
-                            image_url = "/application_assets/image-not-found.png"
-                        ui.image(image_url).classes("object-contain absolute-center max-h-full")
-                        icon, color = run_item_status_and_termination_reason_to_icon_and_color(
-                            item.state.value, item.termination_reason
-                        )
-                        with ui.row().classes("justify-center w-full"):
-                            with ui.icon(icon, color=color).classes("text-4xl pl-2 pt-1").props("floating"):
-                                tooltip = f"Item {item.item_id}, status {item.state.value.upper()}"
-                                if item.termination_reason:
-                                    tooltip += f" ({item.termination_reason})"
-                                ui.tooltip(tooltip)
-                            ui.space()
-                            with ui.button_group():
-                                if find_spec("ijson") and QuPathService.is_qupath_installed():
-                                    with ui.button(
-                                        icon="zoom_in",
-                                        color="primary",
-                                    ).props("floating") as qupath_button:
-                                        qupath_button.on_click(
-                                            lambda _, image_file=image_file, qupath_button=qupath_button: open_qupath(
-                                                image=image_file, button=qupath_button
-                                            )
+                    with ui.row().classes("justify-center w-full"):
+                        with ui.icon(icon, color=color).classes("text-4xl pl-2 pt-1").props("floating"):
+                            tooltip = f"Item {item.item_id}, status {item.state.value.upper()}"
+                            if item.termination_reason:
+                                tooltip += f" ({item.termination_reason})"
+                            ui.tooltip(tooltip)
+                        ui.space()
+                        with ui.button_group():
+                            if find_spec("ijson") and QuPathService.is_qupath_installed():
+                                with ui.button(
+                                    icon="zoom_in",
+                                    color="primary",
+                                ).props("floating") as qupath_button:
+                                    qupath_button.on_click(
+                                        lambda _, image_file=image_file, qupath_button=qupath_button: open_qupath(
+                                            image=image_file, button=qupath_button
                                         )
-                                        ui.tooltip("Open in QuPath")
-                                if item.custom_metadata:
-                                    with ui.button(
-                                        icon="info",
-                                        on_click=lambda _,
-                                        custom_metadata=item.custom_metadata,
-                                        external_id=item.external_id: custom_metadata_dialog_open(
-                                            title=f"Custom Metadata of item {external_id} ",
-                                            custom_metadata=custom_metadata,
-                                        ),
-                                    ).props("floating"):
-                                        ui.tooltip("Show custom metadata")
-                                if image_file:
-                                    with ui.button(
-                                        icon="folder_open",
-                                        on_click=lambda _, image_file=image_file: show_in_file_manager(
-                                            str(image_file.parent)
-                                        ),
-                                    ).props("floating"):
-                                        ui.tooltip("Open folder")
-                        with ui.row().classes(
-                            "absolute-bottom h-32 bg-indigo-700 bg-opacity-80 content-center w-full p-4"
+                                    )
+                                    ui.tooltip("Open in QuPath")
+                            if item.custom_metadata:
+                                with ui.button(
+                                    icon="info",
+                                    on_click=lambda _,
+                                    custom_metadata=item.custom_metadata,
+                                    external_id=item.external_id: custom_metadata_dialog_open(
+                                        title=f"Custom Metadata of item {external_id} ",
+                                        custom_metadata=custom_metadata,
+                                    ),
+                                ).props("floating"):
+                                    ui.tooltip("Show custom metadata")
+                            if image_file:
+                                with ui.button(
+                                    icon="folder_open",
+                                    on_click=lambda _, image_file=image_file: show_in_file_manager(
+                                        str(image_file.parent)
+                                    ),
+                                ).props("floating"):
+                                    ui.tooltip("Open folder")
+                    with ui.row().classes("absolute-bottom h-32 bg-indigo-700 bg-opacity-80 content-center w-full p-4"):
+                        ui.label(item.external_id).classes(
+                            "text-center break-all text-white font-semibold text-shadow-lg/30"
+                        )
+                if item.output is ItemOutput.FULL:
+                    with ui.item_section().classes("w-full"), ui.scroll_area().classes("h-full p-0"):
+                        for artifact in sorted(item.output_artifacts, key=lambda a: str(a.name)):
+                            mime_type = get_mime_type_for_artifact(artifact)
+                            with ui.expansion(
+                                str(artifact.name),
+                                icon=mime_type_to_icon(mime_type),
+                                group="artifacts",
+                            ).classes("w-full"):
+                                if artifact.download_url:
+                                    url = artifact.download_url
+                                    title = artifact.name
+                                    metadata = artifact.metadata
+                                    with ui.button_group():
+                                        if mime_type == "image/tiff":
+                                            ui.button(
+                                                "Preview",
+                                                icon=mime_type_to_icon(mime_type),
+                                                on_click=lambda _, url=url, title=title: tiff_dialog_open(title, url),
+                                            )
+                                        if mime_type == "text/csv":
+                                            ui.button(
+                                                "Preview",
+                                                icon=mime_type_to_icon(mime_type),
+                                                on_click=lambda _, url=url, title=title: csv_dialog_open(title, url),
+                                            )
+                                        if url:
+                                            ui.button(
+                                                text="Download",
+                                                icon="cloud_download",
+                                                on_click=lambda _, url=url: webbrowser.open(url),
+                                            )
+                                        if metadata:
+                                            ui.button(
+                                                text="Schema",
+                                                icon="schema",
+                                                on_click=lambda _, title=title, metadata=metadata: metadata_dialog_open(
+                                                    title, metadata
+                                                ),
+                                            )
+                elif item.state is ItemState.TERMINATED:
+                    if item.error_message:
+                        with (
+                            ui.row()
+                            .classes("w-1/2 justify-start items-start content-start ml-4")
+                            .style("max-width: 50%;")
                         ):
-                            ui.label(item.external_id).classes(
-                                "text-center break-all text-white font-semibold text-shadow-lg/30"
-                            )
-                    if item.output is ItemOutput.FULL:
-                        with ui.item_section().classes("w-full"), ui.scroll_area().classes("h-full p-0"):
-                            for artifact in sorted(item.output_artifacts, key=lambda a: str(a.name)):
-                                mime_type = get_mime_type_for_artifact(artifact)
-                                with ui.expansion(
-                                    str(artifact.name),
-                                    icon=mime_type_to_icon(mime_type),
-                                    group="artifacts",
-                                ).classes("w-full"):
-                                    if artifact.download_url:
-                                        url = artifact.download_url
-                                        title = artifact.name
-                                        metadata = artifact.metadata
-                                        with ui.button_group():
-                                            if mime_type == "image/tiff":
-                                                ui.button(
-                                                    "Preview",
-                                                    icon=mime_type_to_icon(mime_type),
-                                                    on_click=lambda _, url=url, title=title: tiff_dialog_open(
-                                                        title, url
-                                                    ),
-                                                )
-                                            if mime_type == "text/csv":
-                                                ui.button(
-                                                    "Preview",
-                                                    icon=mime_type_to_icon(mime_type),
-                                                    on_click=lambda _, url=url, title=title: csv_dialog_open(
-                                                        title, url
-                                                    ),
-                                                )
-                                            if url:
-                                                ui.button(
-                                                    text="Download",
-                                                    icon="cloud_download",
-                                                    on_click=lambda _, url=url: webbrowser.open(url),
-                                                )
-                                            if metadata:
-                                                ui.button(
-                                                    text="Schema",
-                                                    icon="schema",
-                                                    on_click=lambda _,
-                                                    title=title,
-                                                    metadata=metadata: metadata_dialog_open(title, metadata),
-                                                )
-                    elif item.state is ItemState.TERMINATED:
-                        if item.error_message:
-                            with (
-                                ui.row()
-                                .classes("w-1/2 justify-start items-start content-start ml-4")
-                                .style("max-width: 50%;")
-                            ):
-                                ui.code(
-                                    f"Error: {item.error_message}, code: {item.error_code or 'N/A'}",
-                                    language="markdown",
-                                ).classes("ml-8").style("width: 100%; max-width: 100%;")
-                        else:
-                            with ui.row().classes("w-1/2 justify-center content-center"):
-                                ui.space()
-                                ui.html(
-                                    '<dotlottie-player src="/application_assets/error.lottie" '
-                                    'background="transparent" speed="1" style="width: 300px; height: 300px" '
-                                    'direction="1" playMode="normal" loop autoplay></dotlottie-player>',
-                                    sanitize=False,
-                                )
-                                ui.space()
+                            ui.code(
+                                f"Error: {item.error_message}, code: {item.error_code or 'N/A'}",
+                                language="markdown",
+                            ).classes("ml-8").style("width: 100%; max-width: 100%;")
                     else:
                         with ui.row().classes("w-1/2 justify-center content-center"):
                             ui.space()
-                            animation_file = {
-                                ItemState.PENDING: "pending.lottie",
-                                ItemState.PROCESSING: "processing.lottie",  # TODO(Helmut): Different icon
-                            }[item.state]
                             ui.html(
-                                f'<dotlottie-player src="/application_assets/{animation_file}" '
+                                '<dotlottie-player src="/application_assets/error.lottie" '
                                 'background="transparent" speed="1" style="width: 300px; height: 300px" '
                                 'direction="1" playMode="normal" loop autoplay></dotlottie-player>',
                                 sanitize=False,
                             )
                             ui.space()
+                else:
+                    with ui.row().classes("w-1/2 justify-center content-center"):
+                        ui.space()
+                        animation_file = {
+                            ItemState.PENDING: "pending.lottie",
+                            ItemState.PROCESSING: "processing.lottie",  # TODO(Helmut): Different icon
+                        }[item.state]
+                        ui.html(
+                            f'<dotlottie-player src="/application_assets/{animation_file}" '
+                            'background="transparent" speed="1" style="width: 300px; height: 300px" '
+                            'direction="1" playMode="normal" loop autoplay></dotlottie-player>',
+                            sanitize=False,
+                        )
+                        ui.space()
+
+        def fetch_next_batch() -> list[ItemResult]:
+            """Fetch the next batch of results from the iterator.
+
+            Returns:
+                list[ItemResult]: The next batch of results, up to RESULTS_PAGE_SIZE items.
+            """
+            nonlocal has_more_results
+            batch: list[ItemResult] = []
+            for _ in range(RESULTS_PAGE_SIZE):
+                try:
+                    item = next(results_iterator)
+                    batch.append(item)
+                except StopIteration:
+                    has_more_results = False
+                    break
+            return batch
+
+        # Load initial batch
+        initial_batch = await nicegui_run.io_bound(fetch_next_batch)
+        displayed_results.extend(initial_batch)
+
+        # Check if there are no results at all
+        if not displayed_results:
+            with ui.row().classes("w-full justify-center content-center"):
+                ui.space()
+                ui.html(
+                    '<dotlottie-player src="/application_assets/empty.lottie" '
+                    'background="transparent" speed="1" style="width: 700px; height: 700px" '
+                    'direction="1" playMode="normal" loop autoplay></dotlottie-player>',
+                    sanitize=False,
+                )
+                ui.space()
+            return
+
+        # Create the results list container
+        results_list = ui.list().classes("full-width")
+
+        # Render initial results
+        with results_list:
+            for item in displayed_results:
+                await render_item(item)
+
+        # Create "Show more" button container
+        show_more_container = ui.row().classes("w-full justify-center mt-4")
+
+        async def load_more() -> None:
+            """Load and render the next batch of results."""
+            nonlocal has_more_results
+            show_more_button.disable()
+            show_more_button.props(add="loading")
+
+            # Fetch next batch
+            next_batch = await nicegui_run.io_bound(fetch_next_batch)
+            displayed_results.extend(next_batch)
+
+            # Render new items
+            with results_list:
+                for item in next_batch:
+                    await render_item(item)
+
+            show_more_button.props(remove="loading")
+
+            # Hide button if no more results or remaining count is 0
+            remaining = run_data.statistics.item_count - len(displayed_results)
+            if not has_more_results or remaining <= 0:
+                show_more_container.set_visibility(False)
+            else:
+                show_more_button.enable()
+                # Update button text with count
+                show_more_button.text = f"Show more ({remaining} remaining)"
+
+        # Add "Show more" button
+        with show_more_container:
+            remaining = run_data.statistics.item_count - len(displayed_results)
+            show_more_button = (
+                ui.button(
+                    f"Show more ({remaining} remaining)",
+                    icon="expand_more",
+                    on_click=load_more,
+                )
+                .props("outline")
+                .mark("BUTTON_SHOW_MORE_RESULTS")
+            )
+
+        # Hide button if all results are already loaded or remaining count is 0
+        remaining_initial = run_data.statistics.item_count - len(displayed_results)
+        if not has_more_results or remaining_initial <= 0:
+            show_more_container.set_visibility(False)

--- a/tests/aignostics/application/gui_test.py
+++ b/tests/aignostics/application/gui_test.py
@@ -464,9 +464,7 @@ async def test_gui_run_download(  # noqa: PLR0915
 )
 @pytest.mark.flaky(retries=2, delay=5, only_on=[AssertionError])
 @pytest.mark.timeout(timeout=60)
-async def test_gui_run_results_pagination_show_more_button_visible(
-    user: User, record_property
-) -> None:
+async def test_gui_run_results_pagination_show_more_button_visible(user: User, record_property) -> None:
     """Test that the 'Show more' button is visible when there are more results than the page size."""
     record_property("tested-item-id", "SPEC-APPLICATION-SERVICE, SPEC-GUI-SERVICE")
 

--- a/tests/aignostics/application/gui_test.py
+++ b/tests/aignostics/application/gui_test.py
@@ -464,51 +464,6 @@ async def test_gui_run_download(  # noqa: PLR0915
 )
 @pytest.mark.flaky(retries=2, delay=5, only_on=[AssertionError])
 @pytest.mark.timeout(timeout=60)
-async def test_gui_run_results_pagination_show_more_button_visible(user: User, record_property) -> None:
-    """Test that the 'Show more' button is visible when there are more results than the page size."""
-    record_property("tested-item-id", "SPEC-APPLICATION-SERVICE, SPEC-GUI-SERVICE")
-
-    # Find a run with more items than RESULTS_PAGE_SIZE
-    runs = Service().application_runs(
-        application_id=HETA_APPLICATION_ID,
-        application_version=HETA_APPLICATION_VERSION,
-        has_output=True,
-        limit=10,
-    )
-
-    # Find a run with enough items to test pagination
-    run_with_many_items = None
-    for run in runs:
-        if run.statistics.item_count > RESULTS_PAGE_SIZE:
-            run_with_many_items = run
-            print(f"Found run {run.run_id} with {run.statistics.item_count} items for pagination test.")
-            break
-
-    if run_with_many_items is None:
-        pytest.skip(
-            f"No runs found with more than {RESULTS_PAGE_SIZE} items for "
-            f"{HETA_APPLICATION_ID} ({HETA_APPLICATION_VERSION})"
-        )
-
-    # Navigate to the run page
-    await user.open(f"/application/run/{run_with_many_items.run_id}")
-    await user.should_see(f"Run {run_with_many_items.run_id}", retries=100)
-
-    # Verify "Show more" button is visible
-    await user.should_see(marker="BUTTON_SHOW_MORE_RESULTS", retries=100)
-
-    # Verify the button shows the correct remaining count
-    expected_remaining = run_with_many_items.statistics.item_count - RESULTS_PAGE_SIZE
-    await user.should_see(f"Show more ({expected_remaining} remaining)", retries=100)
-
-
-@pytest.mark.integration
-@pytest.mark.skipif(
-    platform.system() == "Darwin" and platform.machine() == "arm64" and sys.version_info >= (3, 13),
-    reason="GUI tests unstable on macOS Apple Silicon with Python 3.13 (GitHub Actions runner architecture issues)",
-)
-@pytest.mark.flaky(retries=2, delay=5, only_on=[AssertionError])
-@pytest.mark.timeout(timeout=60)
 async def test_gui_run_results_pagination_show_more_button_hidden_when_few_results(
     user: User, silent_logging: None, record_property
 ) -> None:
@@ -547,8 +502,7 @@ async def test_gui_run_results_pagination_show_more_button_hidden_when_few_resul
     # Wait for results to load
     await sleep(3)
 
-    # Verify "Show more" button is NOT visible
-    # The button container should be hidden when all results fit on one page
+    # Verify "Show more" button is NOT visible (element should not exist in DOM)
     await user.should_not_see(marker="BUTTON_SHOW_MORE_RESULTS", retries=10)
 
 
@@ -560,8 +514,15 @@ async def test_gui_run_results_pagination_show_more_button_hidden_when_few_resul
 )
 @pytest.mark.flaky(retries=2, delay=5, only_on=[AssertionError])
 @pytest.mark.timeout(timeout=120)
-async def test_gui_run_results_pagination_load_more_works(user: User, silent_logging: None, record_property) -> None:
-    """Test that clicking 'Show more' loads additional results."""
+async def test_gui_run_results_pagination_show_more(user: User, silent_logging: None, record_property) -> None:
+    """Test pagination 'Show more' button visibility and functionality.
+
+    Verifies:
+    1. Button is visible when there are more results than RESULTS_PAGE_SIZE
+    2. Button shows correct remaining count
+    3. Clicking button loads more results and updates the count
+    4. Button is hidden when all results are loaded
+    """
     record_property("tested-item-id", "SPEC-APPLICATION-SERVICE, SPEC-GUI-SERVICE")
 
     # Find a run with more items than RESULTS_PAGE_SIZE
@@ -592,7 +553,7 @@ async def test_gui_run_results_pagination_load_more_works(user: User, silent_log
     await user.open(f"/application/run/{run_with_many_items.run_id}")
     await user.should_see(f"Run {run_with_many_items.run_id}", retries=100)
 
-    # Verify initial "Show more" button state
+    # Verify "Show more" button is visible with correct initial count
     await user.should_see(marker="BUTTON_SHOW_MORE_RESULTS", retries=100)
     initial_remaining = total_items - RESULTS_PAGE_SIZE
     await user.should_see(f"Show more ({initial_remaining} remaining)", retries=100)
@@ -610,5 +571,4 @@ async def test_gui_run_results_pagination_load_more_works(user: User, silent_log
         await user.should_see(f"Show more ({new_remaining} remaining)", retries=100)
     else:
         # All items loaded - button should be hidden
-        await sleep(2)
-        # The button container should be hidden when all results are loaded
+        await user.should_not_see(marker="BUTTON_SHOW_MORE_RESULTS", retries=20)

--- a/tests/aignostics/application/gui_test.py
+++ b/tests/aignostics/application/gui_test.py
@@ -481,8 +481,7 @@ async def test_gui_run_results_pagination_show_more_button_visible(
     # Find a run with enough items to test pagination
     run_with_many_items = None
     for run in runs:
-        details = run.details()
-        if details.statistics.item_count > RESULTS_PAGE_SIZE:
+        if run.statistics.item_count > RESULTS_PAGE_SIZE:
             run_with_many_items = run
             break
 
@@ -492,8 +491,6 @@ async def test_gui_run_results_pagination_show_more_button_visible(
             f"{HETA_APPLICATION_ID} ({HETA_APPLICATION_VERSION})"
         )
 
-    run_details = run_with_many_items.details()
-
     # Navigate to the run page
     await user.open(f"/application/run/{run_with_many_items.run_id}")
     await user.should_see(f"Run {run_with_many_items.run_id}", retries=100)
@@ -502,7 +499,7 @@ async def test_gui_run_results_pagination_show_more_button_visible(
     await user.should_see(marker="BUTTON_SHOW_MORE_RESULTS", retries=100)
 
     # Verify the button shows the correct remaining count
-    expected_remaining = run_details.statistics.item_count - RESULTS_PAGE_SIZE
+    expected_remaining = run_with_many_items.statistics.item_count - RESULTS_PAGE_SIZE
     await user.should_see(f"Show more ({expected_remaining} remaining)", retries=100)
 
 
@@ -534,8 +531,7 @@ async def test_gui_run_results_pagination_show_more_button_hidden_when_few_resul
     # Find a run with few enough items
     run_with_few_items = None
     for run in runs:
-        details = run.details()
-        if 0 < details.statistics.item_count <= RESULTS_PAGE_SIZE:
+        if 0 < run.statistics.item_count <= RESULTS_PAGE_SIZE:
             run_with_few_items = run
             break
 
@@ -581,8 +577,7 @@ async def test_gui_run_results_pagination_load_more_works(user: User, silent_log
     # Find a run with enough items to test pagination (need at least 2 pages)
     run_with_many_items = None
     for run in runs:
-        details = run.details()
-        if details.statistics.item_count > RESULTS_PAGE_SIZE:
+        if run.statistics.item_count > RESULTS_PAGE_SIZE:
             run_with_many_items = run
             break
 
@@ -592,8 +587,7 @@ async def test_gui_run_results_pagination_load_more_works(user: User, silent_log
             f"{HETA_APPLICATION_ID} ({HETA_APPLICATION_VERSION})"
         )
 
-    run_details = run_with_many_items.details()
-    total_items = run_details.statistics.item_count
+    total_items = run_with_many_items.statistics.item_count
 
     # Navigate to the run page
     await user.open(f"/application/run/{run_with_many_items.run_id}")

--- a/tests/aignostics/application/gui_test.py
+++ b/tests/aignostics/application/gui_test.py
@@ -549,9 +549,7 @@ async def test_gui_run_results_pagination_show_more_button_hidden_when_few_resul
 
     # Verify "Show more" button is NOT visible
     # The button container should be hidden when all results fit on one page
-    button_elements = user.find(marker="BUTTON_SHOW_MORE_RESULTS").elements
-    # If button exists, it should not be visible (container hidden)
-    assert len(button_elements) == 0, "Show more button should not be visible when all results fit on one page"
+    await user.should_not_see(marker="BUTTON_SHOW_MORE_RESULTS", retries=10)
 
 
 @pytest.mark.integration

--- a/tests/aignostics/application/gui_test.py
+++ b/tests/aignostics/application/gui_test.py
@@ -465,7 +465,7 @@ async def test_gui_run_download(  # noqa: PLR0915
 @pytest.mark.flaky(retries=2, delay=5, only_on=[AssertionError])
 @pytest.mark.timeout(timeout=60)
 async def test_gui_run_results_pagination_show_more_button_visible(
-    user: User, silent_logging: None, record_property
+    user: User, record_property
 ) -> None:
     """Test that the 'Show more' button is visible when there are more results than the page size."""
     record_property("tested-item-id", "SPEC-APPLICATION-SERVICE, SPEC-GUI-SERVICE")
@@ -483,6 +483,7 @@ async def test_gui_run_results_pagination_show_more_button_visible(
     for run in runs:
         if run.statistics.item_count > RESULTS_PAGE_SIZE:
             run_with_many_items = run
+            print(f"Found run {run.run_id} with {run.statistics.item_count} items for pagination test.")
             break
 
     if run_with_many_items is None:
@@ -533,6 +534,7 @@ async def test_gui_run_results_pagination_show_more_button_hidden_when_few_resul
     for run in runs:
         if 0 < run.statistics.item_count <= RESULTS_PAGE_SIZE:
             run_with_few_items = run
+            print(f"Found run {run.run_id} with {run.statistics.item_count} items for pagination test.")
             break
 
     if run_with_few_items is None:
@@ -579,6 +581,7 @@ async def test_gui_run_results_pagination_load_more_works(user: User, silent_log
     for run in runs:
         if run.statistics.item_count > RESULTS_PAGE_SIZE:
             run_with_many_items = run
+            print(f"Found run {run.run_id} with {run.statistics.item_count} items for pagination test.")
             break
 
     if run_with_many_items is None:

--- a/tests/aignostics/application/gui_test.py
+++ b/tests/aignostics/application/gui_test.py
@@ -15,6 +15,7 @@ from nicegui.testing import User
 from typer.testing import CliRunner
 
 from aignostics.application import Service
+from aignostics.application._gui._page_application_run_describe import RESULTS_PAGE_SIZE
 from aignostics.cli import cli
 from tests.conftest import assert_notified, normalize_output, print_directory_structure
 from tests.constants_test import (
@@ -454,3 +455,167 @@ async def test_gui_run_download(  # noqa: PLR0915
                 f"File size for {filename} ({actual_size} bytes) is outside allowed range "
                 f"({min_size} to {max_size} bytes, ±{tolerance_percent}% of {expected_size})"
             )
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    platform.system() == "Darwin" and platform.machine() == "arm64" and sys.version_info >= (3, 13),
+    reason="GUI tests unstable on macOS Apple Silicon with Python 3.13 (GitHub Actions runner architecture issues)",
+)
+@pytest.mark.flaky(retries=2, delay=5, only_on=[AssertionError])
+@pytest.mark.timeout(timeout=60)
+async def test_gui_run_results_pagination_show_more_button_visible(
+    user: User, silent_logging: None, record_property
+) -> None:
+    """Test that the 'Show more' button is visible when there are more results than the page size."""
+    record_property("tested-item-id", "SPEC-APPLICATION-SERVICE, SPEC-GUI-SERVICE")
+
+    # Find a run with more items than RESULTS_PAGE_SIZE
+    runs = Service().application_runs(
+        application_id=HETA_APPLICATION_ID,
+        application_version=HETA_APPLICATION_VERSION,
+        has_output=True,
+        limit=10,
+    )
+
+    # Find a run with enough items to test pagination
+    run_with_many_items = None
+    for run in runs:
+        details = run.details()
+        if details.statistics.item_count > RESULTS_PAGE_SIZE:
+            run_with_many_items = run
+            break
+
+    if run_with_many_items is None:
+        pytest.skip(
+            f"No runs found with more than {RESULTS_PAGE_SIZE} items for "
+            f"{HETA_APPLICATION_ID} ({HETA_APPLICATION_VERSION})"
+        )
+
+    run_details = run_with_many_items.details()
+
+    # Navigate to the run page
+    await user.open(f"/application/run/{run_with_many_items.run_id}")
+    await user.should_see(f"Run {run_with_many_items.run_id}", retries=100)
+
+    # Verify "Show more" button is visible
+    await user.should_see(marker="BUTTON_SHOW_MORE_RESULTS", retries=100)
+
+    # Verify the button shows the correct remaining count
+    expected_remaining = run_details.statistics.item_count - RESULTS_PAGE_SIZE
+    await user.should_see(f"Show more ({expected_remaining} remaining)", retries=100)
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    platform.system() == "Darwin" and platform.machine() == "arm64" and sys.version_info >= (3, 13),
+    reason="GUI tests unstable on macOS Apple Silicon with Python 3.13 (GitHub Actions runner architecture issues)",
+)
+@pytest.mark.flaky(retries=2, delay=5, only_on=[AssertionError])
+@pytest.mark.timeout(timeout=60)
+async def test_gui_run_results_pagination_show_more_button_hidden_when_few_results(
+    user: User, silent_logging: None, record_property
+) -> None:
+    """Test that the 'Show more' button is hidden when there are fewer results than the page size.
+
+    Raises:
+        AssertionError: If the button is visible when it shouldn't be.
+    """
+    record_property("tested-item-id", "SPEC-APPLICATION-SERVICE, SPEC-GUI-SERVICE")
+
+    # Find a run with fewer items than RESULTS_PAGE_SIZE
+    runs = Service().application_runs(
+        application_id=HETA_APPLICATION_ID,
+        application_version=HETA_APPLICATION_VERSION,
+        has_output=True,
+        limit=20,
+    )
+
+    # Find a run with few enough items
+    run_with_few_items = None
+    for run in runs:
+        details = run.details()
+        if 0 < details.statistics.item_count <= RESULTS_PAGE_SIZE:
+            run_with_few_items = run
+            break
+
+    if run_with_few_items is None:
+        pytest.skip(
+            f"No runs found with 1-{RESULTS_PAGE_SIZE} items for {HETA_APPLICATION_ID} ({HETA_APPLICATION_VERSION})"
+        )
+
+    # Navigate to the run page
+    await user.open(f"/application/run/{run_with_few_items.run_id}")
+    await user.should_see(f"Run {run_with_few_items.run_id}", retries=100)
+
+    # Wait for results to load
+    await sleep(3)
+
+    # Verify "Show more" button is NOT visible
+    # The button container should be hidden when all results fit on one page
+    button_elements = user.find(marker="BUTTON_SHOW_MORE_RESULTS").elements
+    # If button exists, it should not be visible (container hidden)
+    assert len(button_elements) == 0, "Show more button should not be visible when all results fit on one page"
+
+
+@pytest.mark.integration
+@pytest.mark.long_running
+@pytest.mark.skipif(
+    platform.system() == "Darwin" and platform.machine() == "arm64" and sys.version_info >= (3, 13),
+    reason="GUI tests unstable on macOS Apple Silicon with Python 3.13 (GitHub Actions runner architecture issues)",
+)
+@pytest.mark.flaky(retries=2, delay=5, only_on=[AssertionError])
+@pytest.mark.timeout(timeout=120)
+async def test_gui_run_results_pagination_load_more_works(user: User, silent_logging: None, record_property) -> None:
+    """Test that clicking 'Show more' loads additional results."""
+    record_property("tested-item-id", "SPEC-APPLICATION-SERVICE, SPEC-GUI-SERVICE")
+
+    # Find a run with more items than RESULTS_PAGE_SIZE
+    runs = Service().application_runs(
+        application_id=HETA_APPLICATION_ID,
+        application_version=HETA_APPLICATION_VERSION,
+        has_output=True,
+        limit=10,
+    )
+
+    # Find a run with enough items to test pagination (need at least 2 pages)
+    run_with_many_items = None
+    for run in runs:
+        details = run.details()
+        if details.statistics.item_count > RESULTS_PAGE_SIZE:
+            run_with_many_items = run
+            break
+
+    if run_with_many_items is None:
+        pytest.skip(
+            f"No runs found with more than {RESULTS_PAGE_SIZE} items for "
+            f"{HETA_APPLICATION_ID} ({HETA_APPLICATION_VERSION})"
+        )
+
+    run_details = run_with_many_items.details()
+    total_items = run_details.statistics.item_count
+
+    # Navigate to the run page
+    await user.open(f"/application/run/{run_with_many_items.run_id}")
+    await user.should_see(f"Run {run_with_many_items.run_id}", retries=100)
+
+    # Verify initial "Show more" button state
+    await user.should_see(marker="BUTTON_SHOW_MORE_RESULTS", retries=100)
+    initial_remaining = total_items - RESULTS_PAGE_SIZE
+    await user.should_see(f"Show more ({initial_remaining} remaining)", retries=100)
+
+    # Click "Show more" button
+    user.find(marker="BUTTON_SHOW_MORE_RESULTS").click()
+
+    # Wait for loading to complete
+    await sleep(5)
+
+    # After loading more, the remaining count should decrease
+    new_remaining = total_items - (2 * RESULTS_PAGE_SIZE)
+    if new_remaining > 0:
+        # Button should still be visible with updated count
+        await user.should_see(f"Show more ({new_remaining} remaining)", retries=100)
+    else:
+        # All items loaded - button should be hidden
+        await sleep(2)
+        # The button container should be hidden when all results are loaded


### PR DESCRIPTION
Currently run results are not paginated and can take a very long time to run. After this change, results are paginated in pages of 20 items.

The tests are not ideal as they rely on finding a run with more/less items than 20, and are skipped if not found. We can improve this when switching tests over to the validation-app where creating a run is easy and cheap.