### PR TITLE
fix: replace tkinter.NONE with literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2235,5 +2235,3 @@
 
 
 * @helmut-hoffer-von-ankershoffen made their first contribution
-
-

--- a/src/aignostics/application/_gui/_utils.py
+++ b/src/aignostics/application/_gui/_utils.py
@@ -1,8 +1,8 @@
 """Utility functions for the application GUI."""
 
-from tkinter import NONE
-
 from aignostics.platform import ItemState, ItemTerminationReason, RunState, RunTerminationReason
+
+NONE = "none"
 
 
 def application_id_to_icon(application_id: str) -> str:


### PR DESCRIPTION
Fixes an import error on `macos-latest` runner with Python 3.13.9 ([example run](https://github.com/aignostics/python-sdk/actions/runs/19819641781/job/56778816199)):
```
ImportError while importing test module '/Users/runner/work/python-sdk/python-sdk/tests/aignostics/application/gui_test.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
/opt/homebrew/Cellar/python@3.13/3.13.9_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/importlib/__init__.py:88: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
tests/aignostics/application/gui_test.py:18: in <module>
    from aignostics.application._gui._page_application_run_describe import RESULTS_PAGE_SIZE
src/aignostics/application/_gui/_page_application_run_describe.py:29: in <module>
    from ._frame import _frame
src/aignostics/application/_gui/_frame.py:12: in <module>
    from ._utils import application_id_to_icon, run_status_to_icon_and_color
src/aignostics/application/_gui/_utils.py:3: in <module>
    from tkinter import NONE
/opt/homebrew/Cellar/python@3.13/3.13.9_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/tkinter/__init__.py:38: in <module>
    import _tkinter # If this fails your Python may not be configured for Tk
    ^^^^^^^^^^^^^^^
E   ModuleNotFoundError: No module named '_tkinter'
```
`tkinter.NONE` is simply `'none'` so we replace the import with a constant.