### PR TITLE
feat: show accepted file formats in Launchpad

### DIFF
--- a/src/aignostics/application/_gui/_page_application_describe.py
+++ b/src/aignostics/application/_gui/_page_application_describe.py
@@ -12,6 +12,7 @@ from loguru import logger
 from nicegui import app, binding, ui  # noq
 from nicegui import run as nicegui_run
 
+from aignostics.constants import WSI_SUPPORTED_FILE_EXTENSIONS
 from aignostics.platform import (
     DEFAULT_CPU_PROVISIONING_MODE,
     DEFAULT_FLEX_START_MAX_RUN_DURATION_MINUTES,
@@ -351,6 +352,7 @@ async def _page_application_describe(application_id: str) -> None:  # noqa: C901
             submit_form.wsi_step_label = ui.label(
                 "Select the folder with the whole slide images you want to analyze then click Next."
             )
+            ui.label(f"Supported formats: {', '.join(sorted(WSI_SUPPORTED_FILE_EXTENSIONS))}").classes("text-caption")
             with ui.stepper_navigation():
                 if "pytest" in sys.modules:
                     ui.button("Home", on_click=_pytest_home, icon="folder").mark("BUTTON_PYTEST_HOME")

--- a/tests/aignostics/application/gui_test.py
+++ b/tests/aignostics/application/gui_test.py
@@ -14,6 +14,7 @@ import pytest
 from nicegui.testing import User
 from typer.testing import CliRunner
 
+from aignostics import WSI_SUPPORTED_FILE_EXTENSIONS
 from aignostics.application import Service
 from aignostics.application._gui._page_application_run_describe import RESULTS_PAGE_SIZE
 from aignostics.cli import cli
@@ -233,6 +234,7 @@ async def test_gui_download_dataset_via_application_to_run_cancel_to_find_back( 
 
             # Check the file picker opens and closes
             await user.should_see("Select the folder with the whole slide images you want to analyze then click Next")
+            await user.should_see(f"Supported formats: {', '.join(sorted(WSI_SUPPORTED_FILE_EXTENSIONS))}")
             user.find(marker="BUTTON_WSI_SELECT_DATA").click()
             await user.should_see("Ok")
             await user.should_see("Cancel")


### PR DESCRIPTION
Adding supported file formats when submitting a run:
<img width="548" height="191" alt="Screenshot 2025-12-01 at 14 17 41" src="https://github.com/user-attachments/assets/2527a9c2-45e9-43d7-bd4d-e836c9128f2d" />