### PR TITLE
fix: resolve NiceGUI drawer JavaScript timeout on run results

### DIFF
--- a/src/aignostics/application/_gui/_page_application_run_describe.py
+++ b/src/aignostics/application/_gui/_page_application_run_describe.py
@@ -70,8 +70,8 @@ async def _page_application_run_describe(run_id: str) -> None:  # noqa: C901, PL
 
     spinner = ui.spinner(size="xl").classes("fixed inset-0 m-auto")
     run = await nicegui_run.io_bound(service.application_run, run_id)
+    run_data = await nicegui_run.io_bound(run.details) if run else None
     spinner.set_visibility(False)
-    run_data = run.details() if run else None
 
     if run and run_data:
         icon, color = run_status_to_icon_and_color(


### PR DESCRIPTION
Loading run data asynchronously to avoid blocking the JavaScript event loop. This should prevent timeouts and resulting GUI freezes.