### PR TITLE
fix: render run results frame before loading data

### DIFF
--- a/src/aignostics/application/_gui/_page_application_run_describe.py
+++ b/src/aignostics/application/_gui/_page_application_run_describe.py
@@ -29,7 +29,6 @@ from ._frame import _frame
 from ._utils import (
     mime_type_to_icon,
     run_item_status_and_termination_reason_to_icon_and_color,
-    run_status_to_icon_and_color,
 )
 
 WIDTH_1200px = "width: 1200px; max-width: none"
@@ -68,38 +67,19 @@ async def _page_application_run_describe(run_id: str) -> None:  # noqa: C901, PL
         </style>
     """)
 
+    # Render frame FIRST to establish NiceGUI client connection before any blocking I/O.
+    # This prevents "Response not ready" timeouts on first page load when API calls are slow.
+    await _frame(
+        navigation_title=f"Run {run_id}",
+        left_sidebar=True,
+        args={"run_id": run_id},
+    )
+
+    # Perform I/O operations AFTER the frame is rendered
     spinner = ui.spinner(size="xl").classes("fixed inset-0 m-auto")
     run = await nicegui_run.io_bound(service.application_run, run_id)
     run_data = await nicegui_run.io_bound(run.details) if run else None
     spinner.set_visibility(False)
-
-    if run and run_data:
-        icon, color = run_status_to_icon_and_color(
-            run_data.state.value,
-            run_data.termination_reason,
-            run_data.statistics.item_count,
-            run_data.statistics.item_succeeded_count,
-        )
-        await _frame(
-            navigation_title=(
-                f"Run of {run_data.application_id} ({run_data.version_number}) on "
-                f"{run_data.submitted_at.astimezone().strftime('%m-%d %H:%M')}"
-            ),
-            navigation_icon=icon,
-            navigation_icon_color=color,
-            navigation_icon_tooltip=f"Run {run_data.run_id}, status {run_data.state.value.upper()}",
-            left_sidebar=True,
-            args={"run_id": run_id},
-        )
-    else:
-        await _frame(
-            navigation_title=f"Run {run_id}",
-            navigation_icon="bug_report",
-            navigation_icon_color="negative",
-            navigation_icon_tooltip="Could not load run data",
-            left_sidebar=True,
-            args={"run_id": run_id},
-        )
 
     if run is None:
         ui.label(f"Failed to get run '{run_id}'").mark("LABEL_ERROR")  # type: ignore[unreachable]

--- a/tests/aignostics/application/gui_test.py
+++ b/tests/aignostics/application/gui_test.py
@@ -151,7 +151,7 @@ async def test_gui_cli_submit_to_run_result_delete(
         # Navigate to the extracted run ID
         await user.open(f"/application/run/{run_id}")
         await user.should_see(
-            f"Run of {application.application_id} ({latest_version_number})",
+            f"Run {run_id}",
             retries=100,
         )
         await user.should_see(
@@ -307,7 +307,9 @@ async def test_gui_download_dataset_via_application_to_run_cancel_to_find_back( 
 
             # Check user is redirected to the run page and run is running
             await sleep(5)
-            await user.should_see(f"Run of he-tme ({latest_application_version.number})", retries=200)
+            # The navigation title is now static "Run {run_id}" but we don't know run_id yet.
+            # Check for the application info in the page content instead.
+            await user.should_see(f"Application: he-tme ({latest_application_version.number})", retries=200)
             try:
                 await user.should_see("PENDING", retries=100)
             except AssertionError:
@@ -389,7 +391,7 @@ async def test_gui_run_download(  # noqa: PLR0915
         await user.open(f"/application/run/{run.run_id}")
         await user.should_see(f"Run {run.run_id}", retries=100)
         await user.should_see(
-            f"Run of {run.application_id} ({run.version_number})",
+            f"Application: {run.application_id} ({run.version_number})",
             retries=100,
         )
 


### PR DESCRIPTION
When loading run results, the Launchpad freezes for some seconds. This happens partly because blocking I/O operations happen _before_ rendering the frame.

To prevent this, we render the frame **before** doing the blocking I/O calls. The downside is that some information is not available when rendering the frame, e.g. application ID previously used in the title. Instead, we just display the run ID. All other information about the run (application ID, version and submitted timestamp) are available in the expansion block.
