### PR TITLE
chore: stop passing GCP secrets to Claude workflows

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -509,7 +509,6 @@ Claude Code is integrated into the CI/CD pipeline for:
 # Inputs:
 #   - prompt: "Your task description"
 #   - max_turns: 200 (default)
-#   - platform_environment: staging (default) or production
 ```
 
 #### 2. Automation Mode
@@ -526,21 +525,20 @@ Claude Code is integrated into the CI/CD pipeline for:
 **Inputs**:
 
 ```yaml
-platform_environment: 'staging' | 'production'  # Default: staging
 mode: 'interactive' | 'automation'               # Required
 prompt: 'string'                                 # For automation mode
 max_turns: '200'                                 # Default: 200
 allowed_tools: 'comma,separated,list'            # Default: Read,Write,Edit,Glob,Grep,Bash(git:*),Bash(uv:*),Bash(make:*)
 ```
 
-**Environment Setup** (same as test environment):
+**Environment Setup**:
 
 1. Installs `uv` package manager
 2. Installs dev tools (`.github/workflows/_install_dev_tools.bash`)
 3. Syncs Python dependencies (`uv sync --all-extras`)
 4. Sets up headless display (for GUI tests)
-5. Creates `.env` with Aignostics credentials (staging or production)
-6. Configures GCP credentials for bucket access
+
+**Note**: Claude Code workflows intentionally do NOT have access to Aignostics platform credentials or GCP credentials to prevent accidental credential leakage.
 
 **Claude Configuration**:
 
@@ -555,10 +553,7 @@ claude \
 
 **Secrets Required**:
 
-* `ANTHROPIC_API_KEY` - For Claude Code
-* `AIGNOSTICS_CLIENT_ID_DEVICE_{STAGING|PRODUCTION}`
-* `AIGNOSTICS_REFRESH_TOKEN_{STAGING|PRODUCTION}`
-* `GCP_CREDENTIALS_{STAGING|PRODUCTION}`
+* `ANTHROPIC_API_KEY` - For Claude Code (only secret available to Claude Code workflows)
 
 ### Automated PR Review (claude-code-automation-pr-review.yml)
 
@@ -600,7 +595,6 @@ and adherence to CLAUDE.md guidelines.
 
 * `prompt`: What you want Claude to work on
 * `max_turns`: How many iterations (default 200)
-* `platform_environment`: staging (default) or production
 
 **Example Use Cases**:
 
@@ -618,7 +612,6 @@ and adherence to CLAUDE.md guidelines.
 * ✅ Use `--system-prompt` referencing CLAUDE.md
 * ✅ Limit tool access (`--allowed-tools`)
 * ✅ Set reasonable `--max-turns`
-* ✅ Use staging environment for development
 * ✅ Review Claude's changes before merging
 * ✅ Let Claude explore workflows and test strategies
 
@@ -626,8 +619,8 @@ and adherence to CLAUDE.md guidelines.
 
 * ❌ Grant unrestricted tool access
 * ❌ Skip CLAUDE.md system prompt
-* ❌ Test against production without approval
 * ❌ Merge without human review
+* ❌ Add platform/GCP credentials to Claude Code workflows (security risk)
 
 ## Scheduled Jobs
 

--- a/.github/workflows/_claude-code.yml
+++ b/.github/workflows/_claude-code.yml
@@ -3,11 +3,6 @@ name: "> Claude Code"
 on:
   workflow_call:
     inputs:
-      platform_environment:
-        description: 'Environment to use, that is staging or production'
-        required: false
-        default: 'staging'
-        type: string
       mode:
         description: 'Mode: interactive or automation'
         required: true
@@ -34,18 +29,6 @@ on:
     secrets:
       ANTHROPIC_API_KEY:
         required: true
-      AIGNOSTICS_CLIENT_ID_DEVICE_STAGING:
-        required: false
-      AIGNOSTICS_REFRESH_TOKEN_STAGING:
-        required: false
-      GCP_CREDENTIALS_STAGING:
-        required: false
-      AIGNOSTICS_CLIENT_ID_DEVICE_PRODUCTION:
-        required: false
-      AIGNOSTICS_REFRESH_TOKEN_PRODUCTION:
-        required: false
-      GCP_CREDENTIALS_PRODUCTION:
-        required: false
 
 jobs:
   claude-code:
@@ -79,23 +62,6 @@ jobs:
 
       - name: Setup display
         uses: pyvista/setup-headless-display-action@7d84ae825e6d9297a8e99bdbbae20d1b919a0b19 # v4.2
-
-      - name: Create .env file
-        uses: SpicyPizza/create-envfile@ace6d4f5d7802b600276c23ca417e669f1a06f6f # v2.0.3
-        with:
-          # The following 3 lines are correct even if vscode complains
-          envkey_AIGNOSTICS_API_ROOT: ${{ inputs.platform_environment == 'staging' && 'https://platform-staging.aignostics.com' || 'https://platform.aignostics.com' }}
-          envkey_AIGNOSTICS_CLIENT_ID_DEVICE: ${{ inputs.platform_environment == 'staging' && secrets.AIGNOSTICS_CLIENT_ID_DEVICE_STAGING || secrets.AIGNOSTICS_CLIENT_ID_DEVICE_PRODUCTION }}
-          envkey_AIGNOSTICS_REFRESH_TOKEN: ${{ inputs.platform_environment == 'staging' && secrets.AIGNOSTICS_REFRESH_TOKEN_STAGING || secrets.AIGNOSTICS_REFRESH_TOKEN_PRODUCTION }}
-          fail_on_empty: false
-
-      - name: Set up GCP credentials for bucket access
-        shell: bash
-        env:
-          GCP_CREDENTIALS: ${{ inputs.platform_environment == 'staging' && secrets.GCP_CREDENTIALS_STAGING || secrets.GCP_CREDENTIALS_PRODUCTION }}
-        run: |
-          echo "$GCP_CREDENTIALS" | base64 -d > credentials.json
-          echo "GOOGLE_APPLICATION_CREDENTIALS=$(pwd)/credentials.json" >> $GITHUB_ENV
 
       - name: Print development version info
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/claude-code-automation-operational-excellence-weekly.yml
+++ b/.github/workflows/claude-code-automation-operational-excellence-weekly.yml
@@ -5,15 +5,6 @@ on:
     # Every Monday at 6:00 AM UTC
     - cron: "0 6 * * 1"
   workflow_dispatch:
-    inputs:
-      platform_environment:
-        description: 'Environment'
-        required: false
-        default: 'staging'
-        type: choice
-        options:
-          - staging
-          - production
 
 concurrency:
   group: ${{ github.workflow }}
@@ -23,7 +14,6 @@ jobs:
   operational-excellence:
     uses: ./.github/workflows/_claude-code.yml
     with:
-      platform_environment: ${{ inputs.platform_environment || 'staging' }}
       mode: 'automation'
       track_progress: false
       allowed_tools: 'Read,Write,Edit,Glob,Grep,LS,,WebFetch,WebSearch,Bash(git:*),Bash(gh:*)'
@@ -299,9 +289,3 @@ jobs:
 
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      AIGNOSTICS_CLIENT_ID_DEVICE_STAGING: ${{ secrets.AIGNOSTICS_CLIENT_ID_DEVICE_STAGING }}
-      AIGNOSTICS_REFRESH_TOKEN_STAGING: ${{ secrets.AIGNOSTICS_REFRESH_TOKEN_STAGING }}
-      GCP_CREDENTIALS_STAGING: ${{ secrets.GCP_CREDENTIALS_STAGING }}
-      AIGNOSTICS_CLIENT_ID_DEVICE_PRODUCTION: ${{ secrets.AIGNOSTICS_CLIENT_ID_DEVICE_PRODUCTION }}
-      AIGNOSTICS_REFRESH_TOKEN_PRODUCTION: ${{ secrets.AIGNOSTICS_REFRESH_TOKEN_PRODUCTION }}
-      GCP_CREDENTIALS_PRODUCTION: ${{ secrets.GCP_CREDENTIALS_PRODUCTION }}

--- a/.github/workflows/claude-code-automation-pr-review.yml
+++ b/.github/workflows/claude-code-automation-pr-review.yml
@@ -4,15 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize]
   workflow_dispatch:
-    inputs:
-      platform_environment:
-        description: 'Environment to use'
-        required: false
-        default: 'staging'
-        type: choice
-        options:
-          - staging
-          - production
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}-${{ github.event.pull_request.number || github.sha }}
@@ -22,7 +13,6 @@ jobs:
   claude-review:
     uses: ./.github/workflows/_claude-code.yml
     with:
-      platform_environment: ${{ inputs.platform_environment || 'staging' }}
       mode: 'automation'
       track_progress: ${{ github.event_name != 'workflow_dispatch' && true || false }}
       allowed_tools: 'mcp__github_inline_comment__create_inline_comment,Read,Write,Edit,MultiEdit,Glob,Grep,LS,WebFetch,WebSearch,Bash(git:*),Bash(bun:*),Bash(npm:*),Bash(npx:*),Bash(gh:*),Bash(uv:*),Bash(make:*)'
@@ -225,9 +215,3 @@ jobs:
         **Remember**: This is medical device software. Insist on highest standards. Be thorough, actionable, and kind.
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      AIGNOSTICS_CLIENT_ID_DEVICE_STAGING: ${{ secrets.AIGNOSTICS_CLIENT_ID_DEVICE_STAGING }}
-      AIGNOSTICS_REFRESH_TOKEN_STAGING: ${{ secrets.AIGNOSTICS_REFRESH_TOKEN_STAGING }}
-      GCP_CREDENTIALS_STAGING: ${{ secrets.GCP_CREDENTIALS_STAGING }}
-      AIGNOSTICS_CLIENT_ID_DEVICE_PRODUCTION: ${{ secrets.AIGNOSTICS_CLIENT_ID_DEVICE_PRODUCTION }}
-      AIGNOSTICS_REFRESH_TOKEN_PRODUCTION: ${{ secrets.AIGNOSTICS_REFRESH_TOKEN_PRODUCTION }}
-      GCP_CREDENTIALS_PRODUCTION: ${{ secrets.GCP_CREDENTIALS_PRODUCTION }}

--- a/.github/workflows/claude-code-interactive.yml
+++ b/.github/workflows/claude-code-interactive.yml
@@ -12,15 +12,6 @@ on:
   pull_request_review:
     types: [submitted]
   workflow_dispatch:
-    inputs:
-      platform_environment:
-        description: 'Environment to use'
-        required: false
-        default: 'staging'
-        type: choice
-        options:
-          - staging
-          - production
 
 jobs:
   claude:
@@ -33,14 +24,7 @@ jobs:
       github.event_name == 'workflow_dispatch'
     uses: ./.github/workflows/_claude-code.yml
     with:
-      platform_environment: ${{ inputs.platform_environment || 'staging' }}
       mode: 'interactive'
       track_progress: ${{ github.event_name != 'workflow_dispatch' && true || false }}
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
-      AIGNOSTICS_CLIENT_ID_DEVICE_STAGING: ${{ secrets.AIGNOSTICS_CLIENT_ID_DEVICE_STAGING }}
-      AIGNOSTICS_REFRESH_TOKEN_STAGING: ${{ secrets.AIGNOSTICS_REFRESH_TOKEN_STAGING }}
-      GCP_CREDENTIALS_STAGING: ${{ secrets.GCP_CREDENTIALS_STAGING }}
-      AIGNOSTICS_CLIENT_ID_DEVICE_PRODUCTION: ${{ secrets.AIGNOSTICS_CLIENT_ID_DEVICE_PRODUCTION }}
-      AIGNOSTICS_REFRESH_TOKEN_PRODUCTION: ${{ secrets.AIGNOSTICS_REFRESH_TOKEN_PRODUCTION }}
-      GCP_CREDENTIALS_PRODUCTION: ${{ secrets.GCP_CREDENTIALS_PRODUCTION }}


### PR DESCRIPTION
We should stop injecting GCP secrets into Claude workflows to prevent leaks.

As a result, the `Create .env file` and `Set up GCP credentials for bucket access` steps can no longer run so we remove them; in turn this means we can remove the now-unused `platform_environment` variable.