### PR TITLE
test: fix flaky CLI test

### DIFF
--- a/tests/aignostics/application/cli_test.py
+++ b/tests/aignostics/application/cli_test.py
@@ -9,6 +9,7 @@ from time import sleep
 
 import pytest
 from loguru import logger
+from tenacity import retry, stop_after_attempt, wait_exponential
 from typer.testing import CliRunner
 
 from aignostics.application import Service as ApplicationService
@@ -1047,6 +1048,42 @@ def test_cli_run_dump_and_update_item_custom_metadata(runner: CliRunner) -> None
     assert isinstance(final_metadata, dict), "Final metadata should be a dictionary"
 
 
+@retry(wait=wait_exponential(multiplier=2, max=10), stop=stop_after_attempt(5))
+def list_runs_by_tag(tag: str, runner: CliRunner, expected_count: int = 1) -> list[dict]:
+    """List runs filtered by tag. Returns list of runs.
+
+    Retries to handle eventual consistency.
+
+    Args:
+        runner: CliRunner to use.
+        tag: Tag to filter runs by.
+        expected_count: Minimum number of runs expected (default: 1).
+
+    Raises:
+        RuntimeError: If listing runs fails or expected count not met.
+    """
+    list_result = runner.invoke(
+        cli,
+        [
+            "application",
+            "run",
+            "list",
+            "--tags",
+            tag,
+            "--format",
+            "json",
+        ],
+    )
+    if list_result.exit_code != 0:
+        msg = f"List runs by tag '{tag}' failed"
+        raise RuntimeError(msg)
+    runs_data = json.loads(list_result.stdout)
+    if len(runs_data) < expected_count:
+        msg = f"Expected at least {expected_count} run(s) with tag '{tag}', but found {len(runs_data)}"
+        raise RuntimeError(msg)
+    return runs_data
+
+
 @pytest.mark.e2e
 @pytest.mark.timeout(timeout=60)
 def test_cli_json_format_and_cancel_by_filter_with_dry_run(  # noqa: PLR0915, PLR0914
@@ -1143,22 +1180,9 @@ def test_cli_json_format_and_cancel_by_filter_with_dry_run(  # noqa: PLR0915, PL
 
     try:
         # Step 4: List runs with JSON format and filter by tag
-        list_result = runner.invoke(
-            cli,
-            [
-                "application",
-                "run",
-                "list",
-                "--tags",
-                unique_tag,
-                "--format",
-                "json",
-            ],
-        )
-        assert list_result.exit_code == 0
+        runs_data = list_runs_by_tag(unique_tag, runner, expected_count=1)
 
         # Step 5: Parse JSON output and verify structure
-        runs_data = json.loads(list_result.stdout)
         assert isinstance(runs_data, list), "JSON output should be a list"
         assert len(runs_data) > 0, "Should find at least one run with the unique tag"
 
@@ -1251,6 +1275,9 @@ def test_cli_json_format_and_cancel_by_filter_with_dry_run(  # noqa: PLR0915, PL
         run_id_match_2 = re.search(r"Submitted run with id '([0-9a-f-]+)' for '", output_2)
         assert run_id_match_2, f"Failed to extract run ID from output '{output_2}'"
         run_id_2 = run_id_match_2.group(1)
+
+        # Wait for both runs to appear in the list (handles eventual consistency)
+        list_runs_by_tag(unique_tag, runner, expected_count=2)
 
     finally:
         # Step 10: Test dry-run mode - verify it shows what would be canceled without actually canceling


### PR DESCRIPTION
This test is very flaky: it happens regularly that the submitted run does not appear in the output of the list operation. This is an attempt at making it more reliable by retrying the list operation.