### PR TITLE
fix: prevent Launchpad crash with FastAPI 0.123.7+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ requires-python = ">=3.11, <3.14"
 
 dependencies = [
     # From Template
-    "fastapi[standard,all]>=0.121.3,<1",
+    "fastapi[all,standard]>=0.123.8",
     "humanize>=4.14.0,<5",
     "nicegui[native]>=3.1.0,<3.2.0", # Regression in 3.2.0
     "packaging>=25.0,<26",

--- a/src/aignostics/wsi/_gui.py
+++ b/src/aignostics/wsi/_gui.py
@@ -3,14 +3,12 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING
+
+from fastapi import Response
+from fastapi.responses import RedirectResponse
+from loguru import logger
 
 from aignostics.utils import BasePageBuilder
-
-if TYPE_CHECKING:
-    from fastapi import Response
-
-from loguru import logger
 
 from ._openslide_handler import DEFAULT_MAX_SAFE_DIMENSION
 from ._service import Service
@@ -19,8 +17,6 @@ from ._service import Service
 class PageBuilder(BasePageBuilder):
     @staticmethod
     def register_pages() -> None:
-        from fastapi import Response  # noqa: PLC0415
-        from fastapi.responses import RedirectResponse  # noqa: PLC0415
         from nicegui import app  # noqa: PLC0415
 
         app.add_static_files("/wsi_assets", Path(__file__).parent / "assets")

--- a/uv.lock
+++ b/uv.lock
@@ -161,7 +161,7 @@ requires-dist = [
     { name = "dicom-validator", specifier = ">=0.7.3,<1" },
     { name = "dicomweb-client", extras = ["gcp"], specifier = ">=0.59.3,<1" },
     { name = "duckdb", specifier = ">=0.10.0,<=1.4.1" },
-    { name = "fastapi", extras = ["standard", "all"], specifier = ">=0.121.3,<1" },
+    { name = "fastapi", extras = ["all", "standard"], specifier = ">=0.123.8" },
     { name = "fastparquet", specifier = ">=2024.11.0,<2025" },
     { name = "google-cloud-storage", specifier = ">=3.6.0,<4" },
     { name = "google-crc32c", specifier = ">=1.7.1,<2" },
@@ -1498,7 +1498,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.121.3"
+version = "0.123.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -1506,9 +1506,9 @@ dependencies = [
     { name = "starlette" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/80/f0/086c442c6516195786131b8ca70488c6ef11d2f2e33c9a893576b2b0d3f7/fastapi-0.121.3.tar.gz", hash = "sha256:0055bc24fe53e56a40e9e0ad1ae2baa81622c406e548e501e717634e2dfbc40b", size = 344501, upload-time = "2025-11-19T16:53:39.243Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b8/99/8f2d4be9af90b3e56b865a07bdd390398e53d67c9c95c729b5772e528179/fastapi-0.123.8.tar.gz", hash = "sha256:d106de125c8dd3d4341517fa2ae36d9cffe82a6500bd910d3c080e6c42b1b490", size = 354253, upload-time = "2025-12-04T13:02:54.58Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/b6/4f620d7720fc0a754c8c1b7501d73777f6ba43b57c8ab99671f4d7441eb8/fastapi-0.121.3-py3-none-any.whl", hash = "sha256:0c78fc87587fcd910ca1bbf5bc8ba37b80e119b388a7206b39f0ecc95ebf53e9", size = 109801, upload-time = "2025-11-19T16:53:37.918Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/23/dd53f49e8309454e2c52bdfffe7493cc0f00d10e2fc885d3f4d64c90731f/fastapi-0.123.8-py3-none-any.whl", hash = "sha256:d7c8db95f61d398f7e1491ad52e6b2362755f8ec61c7a740b29e70f18a2901e3", size = 111645, upload-time = "2025-12-04T13:02:53.163Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
FastAPI changed they way they handle imports; to avoid errors, we move the imports to the module root. This might lead to a slight performance decrease overall since we're no longer doing lazy imports; this is preferable to using an outdated version of FastAPI.