### PR TITLE
fix: bring Launchpad to front after successful login

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1102,5 +1102,3 @@
 * @omid-aignostics made their first contribution
 * @idelsink made their first contribution
 * @dependabot[bot] made their first contribution
-
-

--- a/src/aignostics.py
+++ b/src/aignostics.py
@@ -23,7 +23,7 @@ if pyi_splash and pyi_splash.is_alive():
 
 os.environ["LOGFIRE_PYDANTIC_RECORD"] = "off"
 
-from aignostics.constants import SENTRY_INTEGRATIONS  # noqa: E402
+from aignostics.constants import SENTRY_INTEGRATIONS, WINDOW_TITLE  # noqa: E402
 from aignostics.utils import boot, gui_run  # noqa: E402
 
 boot(SENTRY_INTEGRATIONS)
@@ -80,4 +80,4 @@ elif len(sys.argv) > 1 and sys.argv[1] == DEBUG_FLAG:
 else:
     if pyi_splash and pyi_splash.is_alive():
         pyi_splash.update_text("Opening user interface ...")
-    gui_run(native=True, with_api=False, title="Aignostics Launchpad", icon="🔬")
+    gui_run(native=True, with_api=False, title=WINDOW_TITLE, icon="🔬")

--- a/src/aignostics/cli.py
+++ b/src/aignostics/cli.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import typer
 from loguru import logger
 
-from .constants import NOTEBOOK_DEFAULT
+from .constants import NOTEBOOK_DEFAULT, WINDOW_TITLE
 from .utils import (
     __is_running_in_container__,
     __python_version__,
@@ -27,7 +27,7 @@ if find_spec("nicegui") and find_spec("webview") and not __is_running_in_contain
         """Open Aignostics Launchpad, the graphical user interface of the Aignostics Platform."""
         from .utils import gui_run  # noqa: PLC0415
 
-        gui_run(native=True, with_api=False, title="Aignostics Launchpad", icon="🔬")
+        gui_run(native=True, with_api=False, title=WINDOW_TITLE, icon="🔬")
 
 
 if find_spec("marimo"):

--- a/src/aignostics/constants.py
+++ b/src/aignostics/constants.py
@@ -37,3 +37,5 @@ HETA_APPLICATION_ID = "he-tme"
 TEST_APP_APPLICATION_ID = "test-app"
 WSI_SUPPORTED_FILE_EXTENSIONS = {".dcm", ".tiff", ".tif", ".svs"}
 WSI_SUPPORTED_FILE_EXTENSIONS_TEST_APP = {".tiff"}
+
+WINDOW_TITLE = "Aignostics Launchpad"

--- a/src/aignostics/gui/_frame.py
+++ b/src/aignostics/gui/_frame.py
@@ -11,7 +11,9 @@ from typing import Any
 
 from html_sanitizer import Sanitizer
 from humanize import naturaldelta
+from loguru import logger
 
+from aignostics.constants import WINDOW_TITLE
 from aignostics.utils import __version__, open_user_data_directory
 
 from ._theme import theme
@@ -101,15 +103,16 @@ def frame(  # noqa: C901, PLR0915
 
                 # Find window by title since pywebview doesn't expose hwnd directly
                 # FindWindowW(lpClassName, lpWindowName) - use None for class to match any
-                hwnd = ctypes.windll.user32.FindWindowW(None, "Aignostics Launchpad")  # type: ignore
+                hwnd = ctypes.windll.user32.FindWindowW(None, WINDOW_TITLE)  # type: ignore
                 if hwnd:
                     ctypes.windll.user32.SetForegroundWindow(hwnd)  # type: ignore
             else:
                 app.native.main_window.set_always_on_top(True)
                 app.native.main_window.show()
                 app.native.main_window.set_always_on_top(False)
-        except Exception:  # noqa: S110
-            pass  # Window operations can fail on some platforms
+        except Exception as e:
+            logger.exception(f"Failed to bring window to front: {e}")
+            # Window operations can fail on some platforms
 
     user_info: UserInfo | None = None
     launchpad_healthy: bool | None = None
@@ -168,6 +171,8 @@ def frame(  # noqa: C901, PLR0915
         _user_info_ui.refresh()
         with contextlib.suppress(Exception):
             user_info = await run.io_bound(PlatformService.get_user_info, relogin=True)
+            if user_info:
+                _bring_window_to_front()
             app.storage.tab["user_info"] = user_info
         ui.navigate.reload()
 

--- a/src/aignostics/gui/_frame.py
+++ b/src/aignostics/gui/_frame.py
@@ -84,6 +84,33 @@ def frame(  # noqa: C901, PLR0915
                 for item in group.items:
                     _render_nav_item(item)
 
+    def _bring_window_to_front() -> None:
+        """Bring the native window to front after authentication completes.
+
+        Uses platform-specific approaches:
+        - Windows: Uses ctypes to find window by title and call SetForegroundWindow,
+          as pywebview's set_always_on_top/show methods don't reliably bring windows
+          to front and the window handle isn't directly exposed.
+        - macOS/Linux: Uses pywebview's built-in methods.
+        """
+        if not app.native.main_window:
+            return
+        try:
+            if platform.system() == "Windows":
+                import ctypes  # noqa: PLC0415
+
+                # Find window by title since pywebview doesn't expose hwnd directly
+                # FindWindowW(lpClassName, lpWindowName) - use None for class to match any
+                hwnd = ctypes.windll.user32.FindWindowW(None, "Aignostics Launchpad")  # type: ignore
+                if hwnd:
+                    ctypes.windll.user32.SetForegroundWindow(hwnd)  # type: ignore
+            else:
+                app.native.main_window.set_always_on_top(True)
+                app.native.main_window.show()
+                app.native.main_window.set_always_on_top(False)
+        except Exception:  # noqa: S110
+            pass  # Window operations can fail on some platforms
+
     user_info: UserInfo | None = None
     launchpad_healthy: bool | None = None
 
@@ -127,6 +154,8 @@ def frame(  # noqa: C901, PLR0915
         await ui.context.client.connected()
         app.storage.tab["user_info"] = user_info
         _user_info_ui.refresh()
+        if user_info:
+            _bring_window_to_front()
 
     ui.timer(interval=USERINFO_UPDATE_INTERVAL, callback=_user_info_ui_load, immediate=True)
 

--- a/tests/aignostics/cli_test.py
+++ b/tests/aignostics/cli_test.py
@@ -10,6 +10,7 @@ import pytest
 from typer.testing import CliRunner
 
 from aignostics.cli import cli
+from aignostics.constants import WINDOW_TITLE
 from aignostics.utils import (
     __python_version__,
     __version__,
@@ -205,7 +206,7 @@ if find_spec("nicegui"):
 
         # Check that ui.run was called with the expected parameters
         assert mock_ui_run_called, "ui.run was not called"
-        assert mock_ui_run_args["title"] == "Aignostics Launchpad", "title parameter is incorrect"
+        assert mock_ui_run_args["title"] == WINDOW_TITLE, "title parameter is incorrect"
         assert mock_ui_run_args["favicon"] == "🔬", "favicon parameter is incorrect"
         if platform.system() == "Linux":
             assert mock_ui_run_args["native"] is False, "native parameter should be False on Linux"

--- a/tests/main.py
+++ b/tests/main.py
@@ -1,7 +1,8 @@
 """Start script for pytest."""
 
+from aignostics.constants import WINDOW_TITLE
 from aignostics.utils import (
     gui_run,
 )
 
-gui_run(native=False, with_api=False, title="Aignostics Launchpad", icon="🔬")
+gui_run(native=False, with_api=False, title=WINDOW_TITLE, icon="🔬")


### PR DESCRIPTION
This change brings the Launchpad back to the front after successfully authenticating in the browser.