### PR TITLE
test: fix broken tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -338,7 +338,11 @@ asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 timeout = 10 # We use a rather short default timeout. Override with @pytest.mark.timeout(timeout=N)
 # timeout_method="signal" 
-env = ["COVERAGE_FILE=.coverage", "COVERAGE_PROCESS_START=pyproject.toml"]
+env = [
+    "COVERAGE_FILE=.coverage",
+    "COVERAGE_PROCESS_START=pyproject.toml",
+    "COLUMNS=10000",  # Prevent Rich console from wrapping text, which can break string assertions
+]
 markers = [
     # From Template
     "no_extras: Tests that do require no extras installed.",

--- a/tests/aignostics/application/gui_test.py
+++ b/tests/aignostics/application/gui_test.py
@@ -73,9 +73,9 @@ async def test_gui_home_to_application(  # noqa: PLR0913, PLR0917
     await user.should_see(expected_text, retries=300)
 
 
-@pytest.mark.e2e
-@pytest.mark.long_running
-@pytest.mark.flaky(retries=2, delay=5, only_on=[AssertionError])
+# @pytest.mark.e2e
+# @pytest.mark.long_running
+# @pytest.mark.flaky(retries=2, delay=5, only_on=[AssertionError])
 @pytest.mark.timeout(timeout=60 * 5)
 @pytest.mark.sequential
 async def test_gui_cli_submit_to_run_result_delete(
@@ -89,10 +89,7 @@ async def test_gui_cli_submit_to_run_result_delete(
 
     with tempfile.TemporaryDirectory() as tmpdir:
         tmp_path = Path(tmpdir)
-
         application = Service().application(HETA_APPLICATION_ID)
-        latest_version_number = application.versions[0].number if application.versions else None
-        assert latest_version_number is not None, f"No versions found for application {HETA_APPLICATION_ID}"
 
         # Submit run
         csv_content = (
@@ -110,6 +107,8 @@ async def test_gui_cli_submit_to_run_result_delete(
                 "submit",
                 HETA_APPLICATION_ID,
                 str(csv_path),
+                "--application-version",
+                HETA_APPLICATION_VERSION,
                 "--note",
                 "test_gui_cli_submit_to_run_result_delete",
                 "--tags",
@@ -141,11 +140,11 @@ async def test_gui_cli_submit_to_run_result_delete(
         # Navigate to the extracted run ID
         await user.open(f"/application/run/{run_id}")
         await user.should_see(
-            f"Run of {application.application_id} ({latest_version_number})",
+            f"Run of {application.application_id} ({HETA_APPLICATION_VERSION})",
             retries=100,
         )
         await user.should_see(
-            f"Application: {application.application_id} ({latest_version_number})",
+            f"Application: {application.application_id} ({HETA_APPLICATION_VERSION})",
             retries=100,
         )
         try:

--- a/tests/aignostics/application/gui_test.py
+++ b/tests/aignostics/application/gui_test.py
@@ -73,9 +73,9 @@ async def test_gui_home_to_application(  # noqa: PLR0913, PLR0917
     await user.should_see(expected_text, retries=300)
 
 
-# @pytest.mark.e2e
-# @pytest.mark.long_running
-# @pytest.mark.flaky(retries=2, delay=5, only_on=[AssertionError])
+@pytest.mark.e2e
+@pytest.mark.long_running
+@pytest.mark.flaky(retries=2, delay=5, only_on=[AssertionError])
 @pytest.mark.timeout(timeout=60 * 5)
 @pytest.mark.sequential
 async def test_gui_cli_submit_to_run_result_delete(


### PR DESCRIPTION
## Line wrapping
Some tests are failing because of the way the Rich console wraps long lines of text, introducing newline characters which are removed by the `normalize_output` test helper. To prevent this, I set the `COLUMNS` env var to a very large value. Unfortunately, there is no "infinite" value.

## Application version
Other tests are failing because there is a mismatch between the hardcoded `HETA_APPLICATION_VERSION` and the latest available version on the platform; some tests implicitly expect them to match.