### PR TITLE
chore: bump macos-13 runner to macos-15-intel

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -450,7 +450,7 @@ Build standalone native executables for distribution without Python runtime depe
 | **Linux x86_64** | ubuntu-latest | ✅ Stable | Primary platform |
 | **Linux ARM64** | ubuntu-24.04-arm | ⚠️ Experimental | continue-on-error |
 | **macOS ARM (M1+)** | macos-latest | ⚠️ Experimental | Apple Silicon |
-| **macOS Intel** | macos-13 | ⚠️ Experimental | Intel chips |
+| **macOS Intel** | macos-15-intel | ⚠️ Experimental | Intel chips |
 | **Windows x86_64** | windows-latest | ⚠️ Experimental | With UPX compression |
 | **Windows ARM64** | windows-11-arm | ⚠️ Experimental | ARM-based Windows |
 

--- a/.github/workflows/_build-native-only.yml
+++ b/.github/workflows/_build-native-only.yml
@@ -24,7 +24,7 @@ jobs:
             experimental: true
           - runner: macos-latest
             experimental: true
-          - runner: macos-13
+          - runner: macos-15-intel
             experimental: true
           - runner: windows-latest
             experimental: true

--- a/.github/workflows/_package-publish.yml
+++ b/.github/workflows/_package-publish.yml
@@ -35,7 +35,7 @@ jobs:
             experimental: false
           - runner: macos-latest
             experimental: false
-          - runner: macos-13
+          - runner: macos-15-intel
             experimental: false
           - runner: windows-latest
             experimental: false

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -55,7 +55,7 @@ jobs:
           if [[ "$COMMIT_MESSAGE" == *"skip:test:matrix-runner"* ]] || [[ "$PR_LABELS" == *"skip:test:matrix-runner"* ]]; then
             echo 'matrix={"runner":["ubuntu-latest"],"experimental":[false]}' >> $GITHUB_OUTPUT
           else
-            echo 'matrix={"runner":["ubuntu-latest"],"experimental":[false],"include":[{"runner":"ubuntu-24.04-arm","experimental":true},{"runner":"macos-latest","experimental":true},{"runner":"macos-13","experimental":true},{"runner":"windows-latest","experimental":true}]}' >> $GITHUB_OUTPUT
+            echo 'matrix={"runner":["ubuntu-latest"],"experimental":[false],"include":[{"runner":"ubuntu-24.04-arm","experimental":true},{"runner":"macos-latest","experimental":true},{"runner":"macos-15-intel","experimental":true},{"runner":"windows-latest","experimental":true}]}' >> $GITHUB_OUTPUT
           fi
 
   test:


### PR DESCRIPTION
The `macos-13` runner [was deprecated](https://github.com/actions/runner-images/issues/13046). We bump to `macos-15-intel` as suggested.