### PR TITLE
test: declutter test logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -349,7 +349,7 @@ timeout = 10 # We use a rather short default timeout. Override with @pytest.mark
 env = [
     "COVERAGE_FILE=.coverage",
     "COVERAGE_PROCESS_START=pyproject.toml",
-    "COLUMNS=10000",  # Prevent Rich console from wrapping text, which can break string assertions
+    "AIGNOSTICS_CONSOLE_WIDTH=10000",  # Prevent Rich console from wrapping text, which can break string assertions
 ]
 markers = [
     # From Template

--- a/src/aignostics/utils/_console.py
+++ b/src/aignostics/utils/_console.py
@@ -1,15 +1,30 @@
 """Themed rich console."""
 
+import os
+
 from rich.console import Console
 from rich.theme import Theme
 
-console = Console(
-    theme=Theme({
-        "logging.level.info": "purple4",
-        "debug": "light_cyan3",
-        "success": "green",
-        "info": "purple4",
-        "warning": "yellow1",
-        "error": "red1",
-    }),
-)
+
+def _get_console() -> Console:
+    """Get a themed rich console.
+
+    The console width can be set via the AIGNOSTICS_CONSOLE_WIDTH environment variable.
+
+    Returns:
+        Console: The themed rich console.
+    """
+    return Console(
+        theme=Theme({
+            "logging.level.info": "purple4",
+            "debug": "light_cyan3",
+            "success": "green",
+            "info": "purple4",
+            "warning": "yellow1",
+            "error": "red1",
+        }),
+        width=int(os.environ.get("AIGNOSTICS_CONSOLE_WIDTH", "0")) or None,
+    )
+
+
+console = _get_console()

--- a/tests/aignostics/utils/console_test.py
+++ b/tests/aignostics/utils/console_test.py
@@ -1,0 +1,25 @@
+"""Tests for console module."""
+
+import pytest
+
+from aignostics.utils._console import _get_console
+
+
+@pytest.mark.unit
+def test_get_console_default_width(monkeypatch: pytest.MonkeyPatch, record_property) -> None:
+    """Test that the console is created with default width when no env var is set."""
+    record_property("tested-item-id", "SPEC-UTILS-CONSOLE")
+
+    monkeypatch.delenv("AIGNOSTICS_CONSOLE_WIDTH", raising=False)
+    console = _get_console()
+    assert console.width == 80, "Default console width should be 80."
+
+
+@pytest.mark.unit
+def test_get_console_custom_width(monkeypatch: pytest.MonkeyPatch, record_property) -> None:
+    """Test that the console is created with custom width from env var."""
+    record_property("tested-item-id", "SPEC-UTILS-CONSOLE")
+
+    monkeypatch.setenv("AIGNOSTICS_CONSOLE_WIDTH", "100")
+    console = _get_console()
+    assert console.width == 100, "Console width should be set to 100 from env var."


### PR DESCRIPTION
Following https://github.com/aignostics/python-sdk/pull/327 the test logs are polluted by separators with 10k characters. This aims to set the column width for the Rich console without affecting logs from other components.