### PR TITLE
fix(ci): Prevent shell injection in commit message handling + failing console width test

### DIFF
--- a/.github/workflows/build-native-only.yml
+++ b/.github/workflows/build-native-only.yml
@@ -39,9 +39,12 @@ jobs:
             COMMIT_MESSAGE="${{ github.event.head_commit.message }}"
           fi
           # Export for use in other steps (multiline-safe)
-          echo "commit_message<<EOF" >> $GITHUB_OUTPUT
-          echo "$COMMIT_MESSAGE" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          # Use printf with %s to avoid interpreting special characters
+          {
+            echo "commit_message<<EOF"
+            printf "%s\n" "$COMMIT_MESSAGE"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
 
   check-trigger-condition:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -52,9 +52,12 @@ jobs:
             COMMIT_MESSAGE='${{ github.event.head_commit.message }}'
           fi
           # Export for use in other steps (multiline-safe)
-          echo "commit_message<<EOF" >> $GITHUB_OUTPUT
-          echo "$COMMIT_MESSAGE" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
+          # Use printf with %s to avoid interpreting special characters
+          {
+            echo "commit_message<<EOF"
+            printf "%s\n" "$COMMIT_MESSAGE"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
 
   lint:
     needs: [get-commit-message]

--- a/src/aignostics/utils/_console.py
+++ b/src/aignostics/utils/_console.py
@@ -24,6 +24,7 @@ def _get_console() -> Console:
             "error": "red1",
         }),
         width=int(os.environ.get("AIGNOSTICS_CONSOLE_WIDTH", "0")) or None,
+        legacy_windows=False,  # Modern Windows (10+) doesn't need width adjustment
     )
 
 

--- a/tests/aignostics/utils/console_test.py
+++ b/tests/aignostics/utils/console_test.py
@@ -7,14 +7,12 @@ from aignostics.utils._console import _get_console
 
 @pytest.mark.unit
 def test_get_console_default_width(monkeypatch: pytest.MonkeyPatch, record_property) -> None:
-    """Test that the console is created with default width when our env var is not set."""
+    """Test that the console is created with default width when no env var is set."""
     record_property("tested-item-id", "SPEC-UTILS-CONSOLE")
 
-    width = 100
     monkeypatch.delenv("AIGNOSTICS_CONSOLE_WIDTH", raising=False)
-    monkeypatch.setenv("COLUMNS", width)
     console = _get_console()
-    assert console.width == width, f"Default console width should be {width}."
+    assert console.width == 80, "Default console width should be 80."
 
 
 @pytest.mark.unit

--- a/tests/aignostics/utils/console_test.py
+++ b/tests/aignostics/utils/console_test.py
@@ -11,6 +11,7 @@ def test_get_console_default_width(monkeypatch: pytest.MonkeyPatch, record_prope
     record_property("tested-item-id", "SPEC-UTILS-CONSOLE")
 
     monkeypatch.delenv("AIGNOSTICS_CONSOLE_WIDTH", raising=False)
+    monkeypatch.delenv("COLUMNS", raising=False)  # Rich Console uses COLUMNS for width detection
     console = _get_console()
     assert console.width == 80, "Default console width should be 80."
 

--- a/tests/aignostics/utils/console_test.py
+++ b/tests/aignostics/utils/console_test.py
@@ -7,13 +7,14 @@ from aignostics.utils._console import _get_console
 
 @pytest.mark.unit
 def test_get_console_default_width(monkeypatch: pytest.MonkeyPatch, record_property) -> None:
-    """Test that the console is created with default width when no env var is set."""
+    """Test that the console is created with default width when our env var is not set."""
     record_property("tested-item-id", "SPEC-UTILS-CONSOLE")
 
+    width = 100
     monkeypatch.delenv("AIGNOSTICS_CONSOLE_WIDTH", raising=False)
-    monkeypatch.delenv("COLUMNS", raising=False)  # Rich Console uses COLUMNS for width detection
+    monkeypatch.setenv("COLUMNS", width)
     console = _get_console()
-    assert console.width == 80, "Default console width should be 80."
+    assert console.width == width, f"Default console width should be {width}."
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Problem

### 1. Shell Injection Vulnerability in GitHub Workflows

GitHub workflows were failing when commit messages contained markdown code formatting with backticks (e.g., `` `function_name` ``). The shell was interpreting these backticks as command substitution operators, causing errors in the `get-commit-message` job like here for example: https://github.com/aignostics/python-sdk/actions/runs/20129922869/job/57768598886

This occurred when capturing commit messages and writing them to `$GITHUB_OUTPUT` using `echo "$COMMIT_MESSAGE"`.

### 2. Console Width Test Failure on Windows CI

The test `test_get_console_default_width` in [tests/aignostics/utils/console_test.py](tests/aignostics/utils/console_test.py) was failing on windows-latest because Rich Console was defaulting to `legacy_windows=True` mode, which subtracts 1 from the console width (100 → 99) for backwards compatibility with older Windows terminals.

## Solution

### 1. Shell Injection Fix

Replaced `echo "$COMMIT_MESSAGE"` with `printf "%s\n" "$COMMIT_MESSAGE"` in both affected workflows:
- [.github/workflows/build-native-only.yml](.github/workflows/build-native-only.yml)
- [.github/workflows/ci-cd.yml](.github/workflows/ci-cd.yml)

The `printf "%s\n"` command treats the string as literal text without any shell interpretation, safely handling:
- Backticks (`` ` ``)
- Dollar signs (`$`)
- Asterisks (`*`)
- Backslashes (`\`)
- Other special shell characters

The heredoc EOF delimiter continues to ensure multiline safety.

### 2. Console Width Test Fix

**Root Cause**: On Windows CI, Rich Console auto-detected `legacy_windows=True`, causing width=99 instead of 100.

**Solution**: Explicitly set `legacy_windows=False` in [_console.py:27](src/aignostics/utils/_console.py#L27):

```python
return Console(
    theme=Theme({...}),
    width=int(os.environ.get("AIGNOSTICS_CONSOLE_WIDTH", "0")) or None,
    legacy_windows=False,  # Modern Windows (10+) doesn't need width adjustment
)
