### PR TITLE
fix: pin QuPath version to 0.6.0

### DIFF
--- a/src/aignostics/qupath/_gui.py
+++ b/src/aignostics/qupath/_gui.py
@@ -45,7 +45,7 @@ class PageBuilder(BasePageBuilder):
                         if progress.status is InstallProgressState.DOWNLOADING:
                             if progress.archive_path and progress.archive_size:
                                 install_info.set_text(
-                                    f"Downloading QuPath v{progress.archive_version} "
+                                    f"Downloading QuPath {progress.archive_version} "
                                     f"({humanize.naturalsize(float(progress.archive_size))}) "
                                     f"to {progress.archive_path}"
                                 )

--- a/src/aignostics/qupath/_service.py
+++ b/src/aignostics/qupath/_service.py
@@ -35,7 +35,7 @@ from aignostics.utils import (
 
 from ._settings import Settings
 
-QUPATH_VERSION = "0.6.0-rc5"
+QUPATH_VERSION = "0.6.0"
 DOWNLOAD_CHUNK_SIZE = 10 * 1024 * 1024
 QUPATH_LAUNCH_MAX_WAIT_TIME = 30  # seconds, maximum wait time for QuPath to start
 QUPATH_SCRIPT_MAX_EXECUTION_TIME = 60 * 60 * 2  # seconds, maximum wait time for QuPath to run a script


### PR DESCRIPTION
* Pins QuPath to 0.6.0
* Fixes info message; `progress.archive_version` is already prefixed with `v`