### PR TITLE
fix: pin fastparquet<2025.12.0

### DIFF
--- a/CLI_REFERENCE.md
+++ b/CLI_REFERENCE.md
@@ -987,7 +987,7 @@ $ aignostics qupath install [OPTIONS]
 
 **Options**:
 
-* `--version TEXT`: Version of QuPath to install. Do not change this unless you know what you are doing.  [default: 0.6.0-rc5]
+* `--version TEXT`: Version of QuPath to install. Do not change this unless you know what you are doing.  [default: 0.6.0]
 * `--path DIRECTORY`: Path to install QuPath to. If not specified, the default installation path will be used.Do not change this unless you know what you are doing.  [default: (~/Library/Application Support/aignostics)]
 * `--reinstall / --no-reinstall`: Reinstall QuPath even if it is already installed. This will overwrite the existing installation.  [default: reinstall]
 * `--platform-system TEXT`: Override the system to assume for the installation. This is useful for testing purposes.  [default: Darwin]

--- a/noxfile.py
+++ b/noxfile.py
@@ -155,8 +155,10 @@ def audit(session: nox.Session) -> None:
             "-o",
             "reports/vulnerabilities.json",
             "--ignore-vuln",
-            "GHSA-4xh5-x5gv-qwph",
-        )  # https://pyinstaller.org/en/stable/license.html
+            "GHSA-4xh5-x5gv-qwph",  # https://pyinstaller.org/en/stable/license.html
+            "--ignore-vuln",
+            "GHSA-xm59-rqc7-hhvf",  # nbconvert CVE-2025-53000: no fix available
+        )
     except CommandFailed:
         _format_json_with_jq(session, "reports/vulnerabilities.json")
         session.log("pip-audit failed with JSON output, retrying with default format")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,7 +110,7 @@ dependencies = [
     "pandas>=2.3.3,<3",
     "platformdirs>=4.3.2,<5",
     "procrastinate>=3.5.3",
-    "fastparquet>=2024.11.0; python_version < '3.14'",
+    "fastparquet>=2024.11.0,<2025.12.0; python_version < '3.14'",
     "pyarrow>=22.0.0,<23; python_version >= '3.14'",
     "pyjwt[crypto]>=2.10.1,<3",
     "python-dateutil>=2.9.0.post0,<3",

--- a/uv.lock
+++ b/uv.lock
@@ -166,7 +166,7 @@ requires-dist = [
     { name = "dicomweb-client", extras = ["gcp"], specifier = ">=0.59.3,<1" },
     { name = "duckdb", specifier = ">=1.4.2,<=2" },
     { name = "fastapi", extras = ["all", "standard"], specifier = ">=0.123.10" },
-    { name = "fastparquet", marker = "python_full_version < '3.14'", specifier = ">=2024.11.0" },
+    { name = "fastparquet", marker = "python_full_version < '3.14'", specifier = ">=2024.11.0,<2025.12.0" },
     { name = "filelock", specifier = ">=3.20.1" },
     { name = "google-cloud-storage", specifier = ">=3.6.0,<4" },
     { name = "h11", specifier = ">=0.16.0" },


### PR DESCRIPTION
* `fastparquet==2025.12.0` does not provide a pre-built wheel for Python 3.11 on MacOS. We pin to the previous version which _does_ provide one to avoid users having to build the wheel when using the CLI, which can lead to xcode license agreement errors.
* Ignoring https://github.com/advisories/GHSA-xm59-rqc7-hhvf as there's currently no fix available
* Updating docs following QuPath upgrade