### PR TITLE
fix(qupath): annotate input slide once

### DIFF
--- a/src/aignostics/qupath/_service.py
+++ b/src/aignostics/qupath/_service.py
@@ -1224,8 +1224,9 @@ class Service(BaseService):
 
         pid = Service.execute_qupath(
             project=project,
+            image=image.name,
             script=Service._find_groovy_script("annotate"),
-            script_args=[image.name, str(annotations.as_posix())],
+            script_args=[str(annotations.as_posix())],
         )
         if not pid:
             message = "Failed to execute QuPath script for annotations."

--- a/src/aignostics/qupath/scripts/annotate.groovy
+++ b/src/aignostics/qupath/scripts/annotate.groovy
@@ -8,17 +8,15 @@ import java.awt.Color
 import java.io.File
 
 // Parse command line arguments
-if (args.length < 2) {
-    println("Usage: annotate.groovy <image_name> <geojson_path>")
+if (args.length < 1) {
+    println("Usage: annotate.groovy <geojson_path>")
     println("Arguments provided: " + args.join(", "))
     return
 }
 
-def imageName = args[0]
-def jsonPath = args[1]
+def jsonPath = args[0]
 
 println("Script arguments:")
-println("  Image name: " + imageName)
 println("  GeoJSON path: " + jsonPath)
 
 // Check we are in a project
@@ -28,20 +26,15 @@ if (project == null) {
     return
 }
 
-// Load the image data
-println("Looking for image: " + imageName)
-def imageEntry = project.getImageList().find { entry ->
-    entry.getImageName().contains(imageName)
-}
-if (imageEntry == null) {
-    println("Image not found in project. Available images:")
-    project.getImageList().each { entry ->
-        println("  - " + entry.getImageName())
-    }
+// Get the current image data (already loaded by -i flag)
+def imageData = getCurrentImageData()
+if (imageData == null) {
+    println("No image loaded! Did you launch this script with -i?")
     return
 }
-println("Found image: " + imageEntry.getImageName())
-def imageData = imageEntry.readImageData()
+
+def imageName = imageData.getServer().getMetadata().getName()
+println("Processing image: " + imageName)
 
 // Open the geojson
 println("Loading annotations from: " + jsonPath)
@@ -114,5 +107,6 @@ println("Added " + newObjects.size() + " annotations from GeoJSON")
 
 // Save image
 println("Saving image ...")
-imageEntry.saveImageData(imageData)
+imageData.getServer().getMetadata().getName()  // Get image name for logging
+project.getEntry(imageData).saveImageData(imageData)
 println("Saved image.")


### PR DESCRIPTION
We execute a Groovy script in QuPath to annotate the input slide. Currently, we call the QuPath executable with a `-p` flag which indicates which project to use, and we set the name of the file to be annotated in the script arguments. This is inefficient: QuPath calls the script for every image in the project, and annotates the relevant file name on every execution. For HETA executions which have three images (input slide and two heat maps), we therefore annotate the input slide three times with the same annotations. Instead, we should pass the QuPath executable the name of the image in the project, so that it only runs for that image. We can then simplify the script since it will only ever run for the input slide.

This makes opening results in QuPath faster, and leads to 2/3 fewer annotations.