### PR TITLE
chore(deps): bump marshmallow to 3.26.2 due to CVE-2025-68480

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ dependencies = [
     "starlette>=0.49.1",                # GHSA-7f5h-v6xp-fcq8
     "lxml>=6.0.2",                      # For python 3.14 pre-built wheels
     "filelock>=3.20.1",                 # CVE-2025-68146
+    "marshmallow>=3.26.2",              # CVE-2025-68480
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -51,6 +51,7 @@ dependencies = [
     { name = "jsonschema", extra = ["format-nongpl"] },
     { name = "loguru" },
     { name = "lxml" },
+    { name = "marshmallow" },
     { name = "nicegui", extra = ["native"] },
     { name = "openslide-bin" },
     { name = "openslide-python" },
@@ -185,6 +186,7 @@ requires-dist = [
     { name = "loguru", specifier = ">=0.7.3,<1" },
     { name = "lxml", specifier = ">=6.0.2" },
     { name = "marimo", marker = "extra == 'marimo'", specifier = ">=0.18.4,<1" },
+    { name = "marshmallow", specifier = ">=3.26.2" },
     { name = "matplotlib", marker = "extra == 'marimo'", specifier = ">=3.10.7,<4" },
     { name = "nicegui", extras = ["native"], specifier = ">=3.4.0,<4" },
     { name = "openslide-bin", specifier = ">=4.0.0.10,<5" },
@@ -3601,14 +3603,14 @@ wheels = [
 
 [[package]]
 name = "marshmallow"
-version = "3.26.1"
+version = "3.26.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ab/5e/5e53d26b42ab75491cda89b871dab9e97c840bf12c63ec58a1919710cd06/marshmallow-3.26.1.tar.gz", hash = "sha256:e6d8affb6cb61d39d26402096dc0aee12d5a26d490a121f118d2e81dc0719dc6", size = 221825, upload-time = "2025-02-03T15:32:25.093Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/79/de6c16cc902f4fc372236926b0ce2ab7845268dcc30fb2fbb7f71b418631/marshmallow-3.26.2.tar.gz", hash = "sha256:bbe2adb5a03e6e3571b573f42527c6fe926e17467833660bebd11593ab8dfd57", size = 222095, upload-time = "2025-12-22T06:53:53.309Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/34/75/51952c7b2d3873b44a0028b1bd26a25078c18f92f256608e8d1dc61b39fd/marshmallow-3.26.1-py3-none-any.whl", hash = "sha256:3350409f20a70a7e4e11a27661187b77cdcaeb20abca41c1454fe33636bea09c", size = 50878, upload-time = "2025-02-03T15:32:22.295Z" },
+    { url = "https://files.pythonhosted.org/packages/be/2f/5108cb3ee4ba6501748c4908b908e55f42a5b66245b4cfe0c99326e1ef6e/marshmallow-3.26.2-py3-none-any.whl", hash = "sha256:013fa8a3c4c276c24d26d84ce934dc964e2aa794345a0f8c7e5a7191482c8a73", size = 50964, upload-time = "2025-12-22T06:53:51.801Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
See:
* https://github.com/aignostics/python-sdk/actions/runs/20456374041/job/58779266640
* https://uptime.betterstack.com/team/t344596/incidents/899992471