### PR TITLE
fix(ci): skip Ketryx reporting for Dependabot PRs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -133,6 +133,7 @@ jobs:
   ketryx_report_and_check:
     needs: [get-commit-message, lint, audit, test, codeql]
     if: |
+      github.actor != 'dependabot[bot]' &&
       (!contains(needs.get-commit-message.outputs.commit_message, 'skip:ci')) &&
       (!contains(needs.get-commit-message.outputs.commit_message, 'build:native:only')) &&
       !(github.ref_type == 'branch' && startsWith(needs.get-commit-message.outputs.commit_message, 'Bump version:')) &&


### PR DESCRIPTION
Dependabot PRs cannot access repository secrets (in this case `KETRYX_PROJECT` and `KETRYX_API_KEY`), to prevent malicious dependency updates from accessing sensitive information. This means the `ketryx_report_and_check` step fails for all Dependabot PRs (e.g. https://github.com/aignostics/python-sdk/pull/379). This is not a new issue but was ignored until now.

In this PR I skip the Ketryx step when the PR is opened by `dependabot[bot]`. Important:
* All other CI checks (lint, audit, test, codeql) still run normally for Dependabot PRs
* The Ketryx report is still generated when the PR is merged to main