### PR TITLE
chore: fix Claude sticky comments in PR reviews

### DIFF
--- a/.github/workflows/_claude-code.yml
+++ b/.github/workflows/_claude-code.yml
@@ -79,7 +79,6 @@ jobs:
         if: inputs.mode == 'interactive'
         uses: anthropics/claude-code-action@v1
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: ${{ inputs.track_progress }}
           additional_permissions: |
@@ -95,7 +94,6 @@ jobs:
         if: inputs.mode == 'automation'
         uses: anthropics/claude-code-action@v1.0.29
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           track_progress: ${{ inputs.track_progress }}
           use_sticky_comment: ${{ inputs.use_sticky_comment }}


### PR DESCRIPTION
Sticky comments only work when Claude uses the default Claude[bot] user. When we pass a custom token, it uses git github-actions[bot] user and sticky comments don't work.