### PR TITLE
fix(tests): improve test reliability

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,9 +57,9 @@ repos:
       - id: uv-lock
   - repo: local
     hooks:
-      - id: make
-        name: make
-        entry: make
+      - id: lint
+        name: lint
+        entry: make lint
         language: system
         pass_filenames: false
         always_run: true

--- a/noxfile.py
+++ b/noxfile.py
@@ -910,20 +910,36 @@ def _run_test_suite(session: nox.Session, marker: str = "", cov_append: bool = F
     # Determine report type from python version and custom marker
     report_type = _get_report_type(session, custom_marker)
 
-    # Run parallel tests
-    _run_pytest(session, "not sequential", custom_marker, filtered_posargs, report_type)
+    # Run parallel and sequential tests, collecting failures so that coverage and cleanup
+    # always execute even when some tests fail. This ensures Codecov always receives a
+    # complete report (all JUnit XML files, full accumulated coverage) regardless of
+    # individual test failures.
+    failure: CommandFailed | None = None
 
-    # Run sequential tests
+    try:
+        _run_pytest(session, "not sequential", custom_marker, filtered_posargs, report_type)
+    except CommandFailed as exc:
+        failure = exc
+
+    # Always run sequential tests (coverage appended)
     if "--cov-append" not in filtered_posargs:
         filtered_posargs.extend(["--cov-append"])
-    _run_pytest(session, "sequential", custom_marker, filtered_posargs, report_type)
+    try:
+        _run_pytest(session, "sequential", custom_marker, filtered_posargs, report_type)
+    except CommandFailed as exc:
+        failure = failure or exc
 
-    # Generate coverage report in markdown (only after last test suite)
+    # Always generate the coverage report so reports/coverage.xml and reports/coverage.md
+    # are up-to-date for the Codecov upload step even when tests fail.
     # Note: This will be called multiple times, which is fine as it updates the same report
     _generate_coverage_report(session)
 
     # Clean up post test execution
     _cleanup_test_execution(session)
+
+    # Re-raise to propagate the failure to nox / make / CI
+    if failure is not None:
+        raise failure
 
 
 @nox.session(python=[PYTHON_VERSION])

--- a/src/aignostics/bucket/_service.py
+++ b/src/aignostics/bucket/_service.py
@@ -1,6 +1,7 @@
 """Service of the bucket module."""
 
 import hashlib
+import os
 import re
 from collections.abc import Callable, Generator
 from pathlib import Path
@@ -285,6 +286,41 @@ class Service(BaseService):
         return results
 
     @staticmethod
+    def _compute_s3_prefix(
+        what: list[str],
+        what_is_key: bool,
+        compiled_patterns: list[re.Pattern[str]],  # noqa: ARG004
+    ) -> str | None:
+        """Compute the longest common S3 object prefix for server-side filtering.
+
+        When a useful prefix can be determined, passing it to the S3 paginator reduces
+        the number of pages fetched and dramatically improves performance on large buckets.
+
+        Args:
+            what (list[str]): Exact keys (when what_is_key=True) or regex pattern strings.
+            what_is_key (bool): If True, treat entries as exact keys; else as regex patterns.
+            compiled_patterns (list[re.Pattern[str]]): Pre-compiled patterns (reserved for future use).
+
+        Returns:
+            str | None: The longest common prefix, or None if no useful prefix can be inferred.
+        """
+        re_meta = re.compile(r"[.+*?^${}()\[\]|\\]")
+
+        if what_is_key:
+            prefix = os.path.commonprefix(what)
+        else:
+            literal_prefixes: list[str] = []
+            for pattern in what:
+                m = re_meta.search(pattern)
+                literal_prefix = pattern[: m.start()] if m else pattern
+                if not literal_prefix:
+                    return None
+                literal_prefixes.append(literal_prefix)
+            prefix = os.path.commonprefix(literal_prefixes)
+
+        return prefix or None
+
+    @staticmethod
     def find_static(
         what: list[str] | None = None,
         what_is_key: bool = False,
@@ -307,7 +343,7 @@ class Service(BaseService):
         """
         return Service().find(what, what_is_key, detail, include_signed_urls)
 
-    def find(  # noqa: C901
+    def find(  # noqa: C901, PLR0912
         self,
         what: list[str] | None,
         what_is_key: bool = False,
@@ -348,7 +384,11 @@ class Service(BaseService):
 
         s3c = self._get_s3_client()
         paginator = s3c.get_paginator("list_objects_v2")
-        pages = paginator.paginate(Bucket=self.get_bucket_name())
+        paginate_kwargs: dict[str, Any] = {"Bucket": self.get_bucket_name()}
+        prefix = Service._compute_s3_prefix(what, what_is_key, compiled_patterns)
+        if prefix is not None:
+            paginate_kwargs["Prefix"] = prefix
+        pages = paginator.paginate(**paginate_kwargs)
 
         result: list[str | dict[str, Any]] = []
 

--- a/src/aignostics/bucket/_service.py
+++ b/src/aignostics/bucket/_service.py
@@ -321,6 +321,91 @@ class Service(BaseService):
         return prefix or None
 
     @staticmethod
+    def _compile_patterns(patterns: list[str]) -> list[re.Pattern[str]]:
+        """Compile a list of regex pattern strings, raising ValueError on invalid patterns.
+
+        Args:
+            patterns (list[str]): List of regex pattern strings to compile.
+
+        Returns:
+            list[re.Pattern[str]]: Compiled regex patterns.
+
+        Raises:
+            ValueError: If any pattern is invalid regex.
+        """
+        compiled: list[re.Pattern[str]] = []
+        for pattern in patterns:
+            try:
+                compiled.append(re.compile(pattern))
+            except re.error as e:
+                msg = f"Invalid regex pattern '{pattern}': {e}"
+                logger.warning(msg)
+                raise ValueError(msg) from e
+        return compiled
+
+    @staticmethod
+    def _matches_criteria(
+        item_key: str,
+        what: list[str],
+        what_is_key: bool,
+        compiled_patterns: list[re.Pattern[str]],
+    ) -> bool:
+        """Return True if item_key satisfies the search criteria.
+
+        Args:
+            item_key (str): The S3 object key to test.
+            what (list[str]): Exact keys or pattern strings.
+            what_is_key (bool): If True, match by exact key membership; else by regex.
+            compiled_patterns (list[re.Pattern[str]]): Pre-compiled patterns (used when not what_is_key).
+
+        Returns:
+            bool: True if the item matches any criterion.
+        """
+        if what_is_key:
+            return item_key in what
+        return any(pattern.match(item_key) for pattern in compiled_patterns)
+
+    def _build_result_item(
+        self,
+        item: dict[str, Any],
+        detail: bool,
+        include_signed_urls: bool,
+    ) -> str | dict[str, Any]:
+        """Build the result entry for a single S3 object.
+
+        Args:
+            item (dict[str, Any]): Raw S3 object metadata from the paginator.
+            detail (bool): If True, return full metadata dict; else return only the key.
+            include_signed_urls (bool): If True, include a pre-signed download URL.
+
+        Returns:
+            str | dict[str, Any]: Either the object key string or a metadata dict.
+        """
+        item_key: str = item["Key"]
+
+        if detail:
+            size_bytes = item.get("Size", 0)
+            item_data: dict[str, Any] = {
+                "key": item_key,
+                "size": size_bytes,
+                "size_human": humanize.naturalsize(size_bytes),
+                "last_modified": item.get("LastModified"),
+                "etag": item.get("ETag", "").strip('"'),
+                "storage_class": item.get("StorageClass", ""),
+            }
+            if include_signed_urls:
+                item_data["signed_download_url"] = self.create_signed_download_url(item_key)
+            return item_data
+
+        if include_signed_urls:
+            return {
+                "key": item_key,
+                "signed_download_url": self.create_signed_download_url(item_key),
+            }
+
+        return item_key
+
+    @staticmethod
     def find_static(
         what: list[str] | None = None,
         what_is_key: bool = False,
@@ -343,7 +428,7 @@ class Service(BaseService):
         """
         return Service().find(what, what_is_key, detail, include_signed_urls)
 
-    def find(  # noqa: C901, PLR0912
+    def find(
         self,
         what: list[str] | None,
         what_is_key: bool = False,
@@ -372,15 +457,7 @@ class Service(BaseService):
             bucket_prefix = f"{self.get_bucket_name()}/"
             what = [key.removeprefix(bucket_prefix) for key in what]
 
-        compiled_patterns: list[re.Pattern[str]] = []
-        if not what_is_key:
-            for pattern in what:
-                try:
-                    compiled_patterns.append(re.compile(pattern))
-                except re.error as e:
-                    msg = f"Invalid regex pattern '{pattern}': {e}"
-                    logger.warning(msg)
-                    raise ValueError(msg) from e
+        compiled_patterns = [] if what_is_key else self._compile_patterns(what)
 
         s3c = self._get_s3_client()
         paginator = s3c.get_paginator("list_objects_v2")
@@ -393,38 +470,10 @@ class Service(BaseService):
         result: list[str | dict[str, Any]] = []
 
         for page in pages:
-            contents = page.get("Contents", [])
-
-            for item in contents:
-                item_key = item["Key"]
-
-                # Check if item matches criteria
-                matches = (
-                    item_key in what if what_is_key else any(pattern.match(item_key) for pattern in compiled_patterns)
-                )
-                if not matches:
+            for item in page.get("Contents", []):
+                if not self._matches_criteria(item["Key"], what, what_is_key, compiled_patterns):
                     continue
-
-                if detail:
-                    size_bytes = item.get("Size", 0)
-                    item_data = {
-                        "key": item_key,
-                        "size": size_bytes,
-                        "size_human": humanize.naturalsize(size_bytes),
-                        "last_modified": item.get("LastModified"),
-                        "etag": item.get("ETag", "").strip('"'),
-                        "storage_class": item.get("StorageClass", ""),
-                    }
-                    if include_signed_urls:
-                        item_data["signed_download_url"] = self.create_signed_download_url(item_key)
-                    result.append(item_data)
-                elif include_signed_urls:
-                    result.append({
-                        "key": item_key,
-                        "signed_download_url": self.create_signed_download_url(item_key),
-                    })
-                else:
-                    result.append(item_key)
+                result.append(self._build_result_item(item, detail, include_signed_urls))
 
         return result
 

--- a/src/aignostics/platform/resources/runs.py
+++ b/src/aignostics/platform/resources/runs.py
@@ -13,8 +13,7 @@ from time import sleep
 from typing import Any, cast
 
 from aignx.codegen.api.public_api import PublicApi
-from aignx.codegen.exceptions import NotFoundException
-from aignx.codegen.exceptions import ServiceException
+from aignx.codegen.exceptions import NotFoundException, ServiceException
 from aignx.codegen.models import (
     CustomMetadataUpdateRequest,
     ItemCreationRequest,

--- a/src/aignostics/third_party/idc_index.py
+++ b/src/aignostics/third_party/idc_index.py
@@ -29,6 +29,9 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+Additionally, HTTP requests have been updated to include retry logic with exponential backoff
+for transient failures.
 """
 
 # pylint: disable=too-many-lines
@@ -49,6 +52,13 @@ import idc_index_data
 import platformdirs
 import psutil
 import requests
+from tenacity import (
+    RetryCallState,
+    retry,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
 from packaging.version import Version
 from tqdm import tqdm
 
@@ -59,6 +69,40 @@ aws_endpoint_url = "https://s3.amazonaws.com"
 gcp_endpoint_url = "https://storage.googleapis.com"
 asset_endpoint_url = f"https://github.com/ImagingDataCommons/idc-index-data/releases/download/{idc_index_data.__version__}"
 
+_RETRY_ATTEMPTS = 4
+_RETRY_WAIT_MIN = 0.1
+_RETRY_WAIT_MAX = 10.0
+
+
+def _is_retryable_request_error(exception: BaseException) -> bool:
+    if isinstance(exception, (requests.exceptions.ConnectionError, requests.exceptions.Timeout)):
+        return True
+    if isinstance(exception, requests.exceptions.HTTPError):
+        response = exception.response
+        return response is not None and response.status_code >= 500
+    return False
+
+
+def _log_retry_attempt(retry_state: RetryCallState) -> None:
+    logger.warning(
+        "Retrying HTTP request in {} seconds (attempt {} failed with: {})",
+        retry_state.next_action.sleep if retry_state.next_action else 0,
+        retry_state.attempt_number,
+        retry_state.outcome.exception() if retry_state.outcome else "<no outcome>",
+    )
+
+
+@retry(
+    retry=retry_if_exception(_is_retryable_request_error),
+    stop=stop_after_attempt(_RETRY_ATTEMPTS),
+    wait=wait_exponential_jitter(initial=_RETRY_WAIT_MIN, max=_RETRY_WAIT_MAX),
+    before_sleep=_log_retry_attempt,
+    reraise=True,
+)
+def _requests_get_with_retry(url: str, **kwargs: object) -> requests.Response:
+    response = requests.get(url, **kwargs)
+    response.raise_for_status()
+    return response
 
 
 # TODO(Helmut): Clean solution for no-verify-ssl
@@ -379,34 +423,35 @@ class IDCClient:
             )
         else:
             logger.debug("Fetching index {}", index_name)
-            response = requests.get(
-                self.indices_overview[index_name]["url"], timeout=30
+            try:
+                response = _requests_get_with_retry(
+                    self.indices_overview[index_name]["url"], timeout=30
+                )
+            except requests.exceptions.RequestException:
+                logger.exception(
+                    "Failed to fetch index from URL {}",
+                    self.indices_overview[index_name]["url"],
+                )
+                return
+            filepath = os.path.join(
+                self.indices_data_dir,
+                f"{index_name}.parquet",
             )
-            if response.status_code == 200:
-                filepath = os.path.join(
-                    self.indices_data_dir,
-                    f"{index_name}.parquet",
-                )
 
-                os.makedirs(os.path.dirname(filepath), exist_ok=True)
-                with open(filepath, mode="wb") as file:
-                    file.write(response.content)
+            os.makedirs(os.path.dirname(filepath), exist_ok=True)
+            with open(filepath, mode="wb") as file:
+                file.write(response.content)
 
-                index_table = pd.read_parquet(filepath)
-                # index_table = index_table.merge(
-                #    self.index[["series_aws_url", "SeriesInstanceUID"]],
-                #    on="SeriesInstanceUID", how="left"
-                # )
-                # TODO: consider switching to class variable!
-                # setattr(self.__class__, index_name, index_table)
-                setattr(self, index_name, index_table)
-                self.indices_overview[index_name]["installed"] = True
-                self.indices_overview[index_name]["file_path"] = filepath
-
-            else:
-                logger.error(
-                    f"Failed to fetch index from URL {self.indices_overview[index_name]['url']}: {response.status_code}"
-                )
+            index_table = pd.read_parquet(filepath)
+            # index_table = index_table.merge(
+            #    self.index[["series_aws_url", "SeriesInstanceUID"]],
+            #    on="SeriesInstanceUID", how="left"
+            # )
+            # TODO: consider switching to class variable!
+            # setattr(self.__class__, index_name, index_table)
+            setattr(self, index_name, index_table)
+            self.indices_overview[index_name]["installed"] = True
+            self.indices_overview[index_name]["file_path"] = filepath
         # if clinical_index is requested, likely the user will need clinical data
         # download it here, given that the size is small (<2MB as of IDC v19)
         if index_name == "clinical_index":
@@ -1773,22 +1818,19 @@ Destination folder is not empty and sync size is less than total size.
 
                 logger.trace(f"Requesting citation for DOI: {doi}")
 
-                response = requests.get(url, headers=headers, timeout=timeout)
+                try:
+                    response = _requests_get_with_retry(url, headers=headers, timeout=timeout)
+                except requests.exceptions.RequestException:
+                    logger.exception("Failed to get citation for DOI: {}", url)
+                    continue
 
                 logger.trace("Received response: " + str(response.status_code))
 
-                if response.status_code == 200:
-                    if citation_format == self.CITATION_FORMAT_JSON:
-                        citations.append(response.json())
-                    else:
-                        citations.append(response.text)
-                    logger.trace("Received citation: " + citations[-1])
-
+                if citation_format == self.CITATION_FORMAT_JSON:
+                    citations.append(response.json())
                 else:
-                    logger.error(f"Failed to get citation for DOI: {url}")
-                    logger.error(
-                        f"DOI server response status code: {response.status_code}"
-                    )
+                    citations.append(response.text)
+                logger.trace("Received citation: " + citations[-1])
 
         return citations
 

--- a/tests/aignostics/application/cli_test.py
+++ b/tests/aignostics/application/cli_test.py
@@ -1313,7 +1313,7 @@ def list_runs_by_tag(tag: str, runner: CliRunner, expected_count: int = 1) -> li
 
 
 @pytest.mark.e2e
-@pytest.mark.timeout(timeout=60)
+@pytest.mark.timeout(timeout=180)
 def test_cli_json_format_and_cancel_by_filter_with_dry_run(  # noqa: PLR0915, PLR0914
     runner: CliRunner, tmp_path: Path, silent_logging, record_property
 ) -> None:
@@ -1583,23 +1583,32 @@ def test_cli_json_format_and_cancel_by_filter_with_dry_run(  # noqa: PLR0915, PL
             logger.info("Successfully canceled both runs using cancel-by-filter")
 
             # Step 13: Verify runs ARE canceled by describing them again
+            # Use retry to handle read-replica lag and slow API responses after cancel.
             logger.info("Step 13: Verifying runs ARE canceled after actual cancel")
             runs_to_verify = [run_id] + ([run_id_2] if run_id_2 else [])
             for idx, rid in enumerate(runs_to_verify, 1):
-                describe_result = runner.invoke(cli, ["application", "run", "describe", rid, "--format", "json"])
-                assert describe_result.exit_code == 0, (
-                    f"Failed to describe run {idx} after cancel: {describe_result.stdout}"
-                )
-                described_run = json.loads(describe_result.stdout)
-                # Verify run is now TERMINATED
-                assert described_run["state"] == "TERMINATED", (
-                    f"Run {idx} was not canceled (state: {described_run['state']})"
-                )
-                # termination_reason is a top-level field, not nested under output
-                assert described_run["termination_reason"] == "CANCELED_BY_USER", (
-                    f"Run {idx} has unexpected termination reason: {described_run.get('termination_reason')}"
-                )
-                logger.info("Run {} successfully canceled (state: TERMINATED, reason: CANCELED_BY_USER)", idx)
+                for attempt in Retrying(
+                    wait=wait_exponential(multiplier=2, min=1, max=15),
+                    stop=stop_after_attempt(5),
+                    reraise=True,
+                ):
+                    with attempt:
+                        describe_result = runner.invoke(
+                            cli, ["application", "run", "describe", rid, "--format", "json"]
+                        )
+                        assert describe_result.exit_code == 0, (
+                            f"Failed to describe run {idx} after cancel: {describe_result.stdout}"
+                        )
+                        described_run = json.loads(describe_result.stdout)
+                        # Verify run is now TERMINATED
+                        assert described_run["state"] == "TERMINATED", (
+                            f"Run {idx} was not canceled, state: {described_run['state']}"
+                        )
+                        # termination_reason is a top-level field, not nested under output
+                        assert described_run["termination_reason"] == "CANCELED_BY_USER", (
+                            f"Run {idx} has unexpected termination reason: {described_run.get('termination_reason')}"
+                        )
+                        logger.info("Run {} successfully canceled (state: TERMINATED, reason: CANCELED_BY_USER)", idx)
         else:
             # Fallback: cancel individually if we couldn't get the version
             runs_to_cancel = [run_id] + ([run_id_2] if run_id_2 else [])

--- a/tests/aignostics/application/cli_test.py
+++ b/tests/aignostics/application/cli_test.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from loguru import logger
-from tenacity import retry, stop_after_attempt, wait_exponential
+from tenacity import Retrying, retry, stop_after_attempt, wait_exponential
 from typer.testing import CliRunner
 
 from aignostics.application import Service as ApplicationService
@@ -1024,222 +1024,256 @@ def test_cli_run_update_item_metadata_not_dict(runner: CliRunner) -> None:
 
 
 @pytest.mark.e2e
-@pytest.mark.timeout(timeout=120)
-@pytest.mark.skipif(
-    (platform.system() == "Linux" and platform.machine() in {"aarch64", "arm64"})
-    or (platform.system() in {"Darwin", "Windows"}),
-    reason="No parallel runners, otherwise race condition on metadata updates",
-)
+@pytest.mark.timeout(timeout=180)
 @pytest.mark.sequential
-def test_cli_run_dump_and_update_custom_metadata(runner: CliRunner) -> None:
+def test_cli_run_dump_and_update_custom_metadata(runner: CliRunner, tmp_path: Path) -> None:  # noqa: PLR0914, PLR0915
     """Test dumping and updating custom metadata via CLI commands."""
     import json
     import random
 
-    # Step 1: List runs, limit to 1
-    result = runner.invoke(cli, ["application", "run", "list", "--limit", "1"])
-    assert result.exit_code == 0
+    # Submit a dedicated run with a unique tag to avoid shared-state race conditions
+    csv_content = "external_id;checksum_base64_crc32c;resolution_mpp;width_px;height_px;staining_method;tissue;disease;"
+    csv_content += "platform_bucket_url\n"
+    csv_content += ";5onqtA==;0.26268186053789266;7447;7196;H&E;LUNG;LUNG_CANCER;gs://bucket/test"
+    csv_path = tmp_path / "dummy.csv"
+    csv_path.write_text(csv_content)
 
-    # Check if any runs exist
-    if "You did not yet create a run" in result.output:
-        pytest.skip("No runs available. Please run tests that submit runs first.")
-
-    # Extract run ID from the output (format: "- <run_id> of <app>...")
-    normalized_output = normalize_output(result.output)
-    run_id_match = re.search(r"-\s+([a-f0-9\-]{36})\s+of\s+", normalized_output)
-    assert run_id_match is not None, f"Could not extract run ID from list output:\n{normalized_output}"
+    unique_tag = f"test_metadata_{datetime.now(tz=UTC).timestamp()}"
+    submit_result = runner.invoke(
+        cli,
+        [
+            "application",
+            "run",
+            "submit",
+            HETA_APPLICATION_ID,
+            str(csv_path),
+            "--tags",
+            unique_tag,
+            "--deadline",
+            (datetime.now(tz=UTC) + timedelta(minutes=5)).isoformat(),
+        ],
+    )
+    assert submit_result.exit_code == 0
+    submit_output = normalize_output(submit_result.stdout)
+    run_id_match = re.search(r"Submitted run with id '([0-9a-f-]+)' for '", submit_output)
+    assert run_id_match, f"Failed to extract run ID from submit output '{submit_output}'"
     run_id = run_id_match.group(1)
 
-    # Step 2: Dump custom metadata of run
-    result = runner.invoke(cli, ["application", "run", "dump-metadata", run_id])
-    assert result.exit_code == 0
-    initial_metadata = json.loads(result.stdout)
-    # If metadata is None/null, start with empty dict
-    if initial_metadata is None:
-        initial_metadata = {}
-    assert isinstance(initial_metadata, dict), "Custom metadata should be a dictionary"
+    try:
+        # Step 1: Dump initial custom metadata of run
+        result = runner.invoke(cli, ["application", "run", "dump-metadata", run_id])
+        assert result.exit_code == 0
+        initial_metadata = json.loads(result.stdout)
+        # If metadata is None/null, start with empty dict
+        if initial_metadata is None:
+            initial_metadata = {}
+        assert isinstance(initial_metadata, dict), "Custom metadata should be a dictionary"
 
-    # Store initial SDK metadata timestamps for comparison
-    initial_created_at = initial_metadata.get("sdk", {}).get("created_at")
-    initial_submission_date = initial_metadata.get("sdk", {}).get("submission", {}).get("date")
-    initial_updated_at = initial_metadata.get("sdk", {}).get("updated_at")
+        # Store initial SDK metadata timestamps for comparison
+        initial_created_at = initial_metadata.get("sdk", {}).get("created_at")
+        initial_submission_date = initial_metadata.get("sdk", {}).get("submission", {}).get("date")
+        initial_updated_at = initial_metadata.get("sdk", {}).get("updated_at")
 
-    # Ensure some time passes to see timestamp changes
-    sleep(1)
+        # Ensure some time passes to see timestamp changes
+        sleep(1)
 
-    # Step 3: Add "random" node with a random number
-    random_value = random.randint(1000, 9999)
-    updated_metadata = initial_metadata.copy()
-    updated_metadata["random"] = random_value
+        # Step 2: Add "random" node with a random number
+        random_value = random.randint(1000, 9999)
+        updated_metadata = initial_metadata.copy()
+        updated_metadata["random"] = random_value
 
-    # Update the custom metadata
-    result = runner.invoke(cli, ["application", "run", "update-metadata", run_id, json.dumps(updated_metadata)])
-    assert result.exit_code == 0
-    assert "Successfully updated custom metadata" in result.output
+        # Update the custom metadata
+        result = runner.invoke(cli, ["application", "run", "update-metadata", run_id, json.dumps(updated_metadata)])
+        assert result.exit_code == 0
+        assert "Successfully updated custom metadata" in result.output
 
-    # Step 4: Dump metadata again and verify random number appeared
-    result = runner.invoke(cli, ["application", "run", "dump-metadata", run_id, "--pretty"])
-    assert result.exit_code == 0
-    metadata_with_random = json.loads(result.stdout)
-    assert "random" in metadata_with_random, "Random field should be present in metadata"
-    assert metadata_with_random["random"] == random_value, f"Random value should be {random_value}"
+        # Step 3: Dump metadata again with retry to handle read-replica lag after write
+        metadata_with_random: dict = {}
+        for attempt in Retrying(wait=wait_exponential(multiplier=2, max=10), stop=stop_after_attempt(5)):
+            with attempt:
+                result = runner.invoke(cli, ["application", "run", "dump-metadata", run_id, "--pretty"])
+                assert result.exit_code == 0
+                metadata_with_random = json.loads(result.stdout)
+                assert "random" in metadata_with_random, "Random field should be present in metadata"
+                assert metadata_with_random["random"] == random_value, f"Random value should be {random_value}"
 
-    # Verify SDK metadata timestamps behavior after update
-    updated_created_at = metadata_with_random.get("sdk", {}).get("created_at")
-    updated_submission_date = metadata_with_random.get("sdk", {}).get("submission", {}).get("date")
-    updated_updated_at = metadata_with_random.get("sdk", {}).get("updated_at")
+        # Verify SDK metadata timestamps behavior after update
+        updated_created_at = metadata_with_random.get("sdk", {}).get("created_at")
+        updated_submission_date = metadata_with_random.get("sdk", {}).get("submission", {}).get("date")
+        updated_updated_at = metadata_with_random.get("sdk", {}).get("updated_at")
 
-    # created_at and submission.date should NOT change
-    # Only check created_at immutability if it was set initially
-    if initial_created_at is not None:
-        assert updated_created_at == initial_created_at, (
-            f"sdk.created_at should not change: {initial_created_at} -> {updated_created_at}"
+        # created_at and submission.date should NOT change
+        if initial_created_at is not None:
+            assert updated_created_at == initial_created_at, (
+                f"sdk.created_at should not change: {initial_created_at} -> {updated_created_at}"
+            )
+
+        if initial_submission_date is not None:
+            assert updated_submission_date == initial_submission_date, (
+                f"sdk.submission.date should not change: {initial_submission_date} -> {updated_submission_date}"
+            )
+
+        # updated_at SHOULD change (be more recent)
+        assert updated_updated_at != initial_updated_at, (
+            f"sdk.updated_at should change after update: {initial_updated_at} -> {updated_updated_at}"
+        )
+        assert updated_updated_at > initial_updated_at, (
+            f"sdk.updated_at should be more recent: {initial_updated_at} -> {updated_updated_at}"
         )
 
-    if initial_submission_date is not None:
-        assert updated_submission_date == initial_submission_date, (
-            f"sdk.submission.date should not change: {initial_submission_date} -> {updated_submission_date}"
-        )
+        # Step 4: Remove the random number
+        del updated_metadata["random"]
+        result = runner.invoke(cli, ["application", "run", "update-metadata", run_id, json.dumps(updated_metadata)])
+        assert result.exit_code == 0
+        assert "Successfully updated custom metadata" in result.output
 
-    # updated_at SHOULD change (be more recent)
-    assert updated_updated_at != initial_updated_at, (
-        f"sdk.updated_at should change after update: {initial_updated_at} -> {updated_updated_at}"
-    )
-    assert updated_updated_at > initial_updated_at, (
-        f"sdk.updated_at should be more recent: {initial_updated_at} -> {updated_updated_at}"
-    )
+        # Step 5: Dump metadata and validate random element removed, with retry for read-replica lag
+        final_metadata: dict = {}
+        for attempt in Retrying(wait=wait_exponential(multiplier=2, max=10), stop=stop_after_attempt(5)):
+            with attempt:
+                result = runner.invoke(cli, ["application", "run", "dump-metadata", run_id])
+                assert result.exit_code == 0
+                final_metadata = json.loads(result.stdout)
+                assert "random" not in final_metadata, "Random field should have been removed from metadata"
 
-    # Step 5: Remove the random number
-    del updated_metadata["random"]
-    result = runner.invoke(cli, ["application", "run", "update-metadata", run_id, json.dumps(updated_metadata)])
-    assert result.exit_code == 0
-    assert "Successfully updated custom metadata" in result.output
-
-    # Step 6: Dump metadata and validate random element has been removed
-    result = runner.invoke(cli, ["application", "run", "dump-metadata", run_id])
-    assert result.exit_code == 0
-    final_metadata = json.loads(result.stdout)
-    assert "random" not in final_metadata, "Random field should have been removed from metadata"
-
-    # Note: We can't compare final_metadata == initial_metadata because the SDK
-    # automatically updates some fields (e.g., submission.date, ci.pytest.current_test)
-    # when operations are performed. Instead, verify the random field was removed
-    # and the structure remains consistent.
-    assert isinstance(final_metadata, dict), "Final metadata should be a dictionary"
+        # Note: We can't compare final_metadata == initial_metadata because the SDK
+        # automatically updates some fields (e.g., submission.date, ci.pytest.current_test)
+        # when operations are performed. Instead, verify the random field was removed
+        # and the structure remains consistent.
+        assert isinstance(final_metadata, dict), "Final metadata should be a dictionary"
+    finally:
+        runner.invoke(cli, ["application", "run", "cancel", run_id])
 
 
 @pytest.mark.e2e
-@pytest.mark.timeout(timeout=120)
-@pytest.mark.skipif(
-    (platform.system() == "Linux" and platform.machine() in {"aarch64", "arm64"})
-    or (platform.system() in {"Darwin", "Windows"}),
-    reason="No parallel runners, otherwise race condition on metadata updates",
-)
+@pytest.mark.timeout(timeout=240)
 @pytest.mark.sequential
-def test_cli_run_dump_and_update_item_custom_metadata(runner: CliRunner) -> None:  # noqa: PLR0914, PLR0915  # noqa: PLR0914, PLR0915
+def test_cli_run_dump_and_update_item_custom_metadata(runner: CliRunner, tmp_path: Path) -> None:  # noqa: PLR0914, PLR0915
     """Test dumping and updating item custom metadata via CLI commands."""
     import json
     import random
 
-    # Step 1: List runs, limit to 1
-    result = runner.invoke(cli, ["application", "run", "list", "--limit", "1"])
-    assert result.exit_code == 0
+    # Submit a dedicated run with a unique tag to avoid shared-state race conditions.
+    # Use a non-empty external_id so describe output contains a matchable "Item External ID: `...`".
+    csv_content = "external_id;checksum_base64_crc32c;resolution_mpp;width_px;height_px;staining_method;tissue;disease;"
+    csv_content += "platform_bucket_url\n"
+    csv_content += "dummy-item-001;5onqtA==;0.26268186053789266;7447;7196;H&E;LUNG;LUNG_CANCER;gs://bucket/test"
+    csv_path = tmp_path / "dummy.csv"
+    csv_path.write_text(csv_content)
 
-    # Check if any runs exist
-    if "You did not yet create a run" in result.output:
-        pytest.skip("No runs available. Please run tests that submit runs first.")
-
-    # Extract run ID from the output (format: "- <run_id> of <app>...")
-    normalized_output = normalize_output(result.output)
-    run_id_match = re.search(r"-\s+([a-f0-9\-]{36})\s+of\s+", normalized_output)
-    assert run_id_match is not None, f"Could not extract run ID from list output:\n{normalized_output}"
-    run_id = run_id_match.group(1)
-    print(run_id)
-
-    # Get run details to extract an item's external_id
-    result = runner.invoke(cli, ["application", "run", "describe", run_id])
-    assert result.exit_code == 0
-
-    normalized_describe = normalize_output(result.output)
-    # Match the external ID wrapped in backticks - external ID can contain spaces
-    external_id_match = re.search(r"Item External ID:\s*`([^`]+)`", normalized_describe)
-
-    if not external_id_match:
-        pytest.skip("Could not extract item external_id from run. Run may not have items yet.")
-
-    external_id = external_id_match.group(1).strip()
-    print(external_id)
-
-    # Step 2: Dump custom metadata of item
-    result = runner.invoke(cli, ["application", "run", "dump-item-metadata", run_id, external_id])
-    initial_metadata = json.loads(result.stdout)
-    # If metadata is None/null, start with empty dict
-    if initial_metadata is None:
-        initial_metadata = {}
-    assert isinstance(initial_metadata, dict), "Custom metadata should be a dictionary"
-    assert result.exit_code == 0
-
-    # Store initial SDK metadata timestamps for comparison
-    initial_created_at = initial_metadata.get("sdk", {}).get("created_at")
-    initial_updated_at = initial_metadata.get("sdk", {}).get("updated_at")
-
-    # Ensure some time passes to see timestamp changes
-    sleep(1)
-
-    # Step 3: Add "random" node with a random number
-    random_value = random.randint(1000, 9999)
-    updated_metadata = initial_metadata.copy()
-    updated_metadata["random"] = random_value
-
-    # Update the custom metadata
-    result = runner.invoke(
-        cli, ["application", "run", "update-item-metadata", run_id, external_id, json.dumps(updated_metadata)]
+    unique_tag = f"test_item_metadata_{datetime.now(tz=UTC).timestamp()}"
+    submit_result = runner.invoke(
+        cli,
+        [
+            "application",
+            "run",
+            "submit",
+            HETA_APPLICATION_ID,
+            str(csv_path),
+            "--tags",
+            unique_tag,
+            "--deadline",
+            (datetime.now(tz=UTC) + timedelta(minutes=5)).isoformat(),
+        ],
     )
-    assert result.exit_code == 0
-    assert "Successfully updated custom metadata" in result.output
+    assert submit_result.exit_code == 0
+    submit_output = normalize_output(submit_result.stdout)
+    run_id_match = re.search(r"Submitted run with id '([0-9a-f-]+)' for '", submit_output)
+    assert run_id_match, f"Failed to extract run ID from submit output '{submit_output}'"
+    run_id = run_id_match.group(1)
 
-    # Step 4: Dump metadata again and verify random number appeared
-    result = runner.invoke(cli, ["application", "run", "dump-item-metadata", run_id, external_id, "--pretty"])
-    metadata_with_random = json.loads(result.stdout)
-    assert "random" in metadata_with_random, "Random field should be present in metadata"
-    assert metadata_with_random["random"] == random_value, f"Random value should be {random_value}"
-    assert result.exit_code == 0
+    try:
+        # Wait for items to appear in the run (describe until external_id is available)
+        @retry(wait=wait_exponential(multiplier=1, max=15), stop=stop_after_attempt(8))
+        def get_external_id() -> str:
+            describe_result = runner.invoke(cli, ["application", "run", "describe", run_id])
+            assert describe_result.exit_code == 0, f"describe failed: {describe_result.output}"
+            normalized = normalize_output(describe_result.output)
+            match = re.search(r"Item External ID:\s*`([^`]+)`", normalized)
+            if not match:
+                msg = "No item external_id available in run yet"
+                raise RuntimeError(msg)
+            return match.group(1).strip()
 
-    # Verify SDK metadata timestamps behavior after update
-    updated_created_at = metadata_with_random.get("sdk", {}).get("created_at")
-    updated_updated_at = metadata_with_random.get("sdk", {}).get("updated_at")
+        external_id = get_external_id()
 
-    # created_at should NOT change
-    if initial_created_at is not None:
-        assert updated_created_at == initial_created_at, (
-            f"sdk.created_at should not change: {initial_created_at} -> {updated_created_at}"
+        # Step 1: Dump initial custom metadata of item
+        result = runner.invoke(cli, ["application", "run", "dump-item-metadata", run_id, external_id])
+        assert result.exit_code == 0
+        initial_metadata = json.loads(result.stdout)
+        # If metadata is None/null, start with empty dict
+        if initial_metadata is None:
+            initial_metadata = {}
+        assert isinstance(initial_metadata, dict), "Custom metadata should be a dictionary"
+
+        # Store initial SDK metadata timestamps for comparison
+        initial_created_at = initial_metadata.get("sdk", {}).get("created_at")
+        initial_updated_at = initial_metadata.get("sdk", {}).get("updated_at")
+
+        # Ensure some time passes to see timestamp changes
+        sleep(1)
+
+        # Step 2: Add "random" node with a random number
+        random_value = random.randint(1000, 9999)
+        updated_metadata = initial_metadata.copy()
+        updated_metadata["random"] = random_value
+
+        # Update the custom metadata
+        result = runner.invoke(
+            cli, ["application", "run", "update-item-metadata", run_id, external_id, json.dumps(updated_metadata)]
+        )
+        assert result.exit_code == 0
+        assert "Successfully updated custom metadata" in result.output
+
+        # Step 3: Dump metadata again with retry to handle read-replica lag after write
+        metadata_with_random: dict = {}
+        for attempt in Retrying(wait=wait_exponential(multiplier=2, max=10), stop=stop_after_attempt(5)):
+            with attempt:
+                result = runner.invoke(
+                    cli, ["application", "run", "dump-item-metadata", run_id, external_id, "--pretty"]
+                )
+                assert result.exit_code == 0
+                metadata_with_random = json.loads(result.stdout)
+                assert "random" in metadata_with_random, "Random field should be present in metadata"
+                assert metadata_with_random["random"] == random_value, f"Random value should be {random_value}"
+
+        # Verify SDK metadata timestamps behavior after update
+        updated_created_at = metadata_with_random.get("sdk", {}).get("created_at")
+        updated_updated_at = metadata_with_random.get("sdk", {}).get("updated_at")
+
+        # created_at should NOT change
+        if initial_created_at is not None:
+            assert updated_created_at == initial_created_at, (
+                f"sdk.created_at should not change: {initial_created_at} -> {updated_created_at}"
+            )
+
+        # updated_at SHOULD change (be more recent)
+        assert updated_updated_at != initial_updated_at, (
+            f"sdk.updated_at should change after update: {initial_updated_at} -> {updated_updated_at}"
         )
 
-    # updated_at SHOULD change (be more recent)
-    assert updated_updated_at != initial_updated_at, (
-        f"sdk.updated_at should change after update: {initial_updated_at} -> {updated_updated_at}"
-    )
-    # Step 5: Remove the random numberresult.output)
-    assert "random" in metadata_with_random, "Random field should be present in metadata"
-    assert metadata_with_random["random"] == random_value, f"Random value should be {random_value}"
+        # Step 4: Remove the random number
+        del updated_metadata["random"]
+        result = runner.invoke(
+            cli, ["application", "run", "update-item-metadata", run_id, external_id, json.dumps(updated_metadata)]
+        )
+        assert result.exit_code == 0
+        assert "Successfully updated custom metadata" in result.output
 
-    # Step 5: Remove the random number
-    del updated_metadata["random"]
-    result = runner.invoke(
-        cli, ["application", "run", "update-item-metadata", run_id, external_id, json.dumps(updated_metadata)]
-    )
-    assert result.exit_code == 0
-    assert "Successfully updated custom metadata" in result.output
+        # Step 5: Dump metadata and validate random element removed, with retry for read-replica lag
+        final_metadata: dict = {}
+        for attempt in Retrying(wait=wait_exponential(multiplier=2, max=10), stop=stop_after_attempt(5)):
+            with attempt:
+                result = runner.invoke(cli, ["application", "run", "dump-item-metadata", run_id, external_id])
+                assert result.exit_code == 0
+                final_metadata = json.loads(result.stdout)
+                assert "random" not in final_metadata, "Random field should have been removed from metadata"
 
-    # Step 6: Dump metadata and validate random element has been removed
-    result = runner.invoke(cli, ["application", "run", "dump-item-metadata", run_id, external_id])
-    assert result.exit_code == 0
-    final_metadata = json.loads(result.stdout)
-    assert "random" not in final_metadata, "Random field should have been removed from metadata"
-
-    # Note: Similar to run metadata, we verify the structure remains consistent
-    # rather than doing exact equality comparison due to dynamic fields
-    assert isinstance(final_metadata, dict), "Final metadata should be a dictionary"
+        # Note: Similar to run metadata, we verify the structure remains consistent
+        # rather than doing exact equality comparison due to dynamic fields
+        assert isinstance(final_metadata, dict), "Final metadata should be a dictionary"
+    finally:
+        runner.invoke(cli, ["application", "run", "cancel", run_id])
 
 
 @retry(wait=wait_exponential(multiplier=2, max=10), stop=stop_after_attempt(5))

--- a/tests/aignostics/bucket/service_test.py
+++ b/tests/aignostics/bucket/service_test.py
@@ -1,10 +1,37 @@
 """Tests of the bucket service."""
 
+from typing import Any
 from unittest import mock
 
 import pytest
 
 from aignostics.bucket._service import Service
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_page(keys: list[str]) -> dict[str, Any]:
+    """Build a mock S3 ListObjectsV2 page response with the given object keys."""
+    return {
+        "Contents": [
+            {"Key": k, "Size": 1024, "LastModified": None, "ETag": '"abc123"', "StorageClass": "STANDARD"} for k in keys
+        ]
+    }
+
+
+def _setup_find(mock_get_s3_client: mock.MagicMock, pages: list[dict[str, Any]]) -> tuple["Service", mock.MagicMock]:
+    """Wire up a Service with a mock S3 paginator returning the given pages."""
+    mock_s3c = mock.MagicMock()
+    mock_paginator = mock.MagicMock()
+    mock_s3c.get_paginator.return_value = mock_paginator
+    mock_paginator.paginate.return_value = pages
+    mock_get_s3_client.return_value = mock_s3c
+
+    service = Service()
+    service.get_bucket_name = mock.MagicMock(return_value="test-bucket")  # type: ignore[method-assign]
+    return service, mock_paginator
 
 
 @pytest.mark.integration
@@ -57,3 +84,156 @@ def test_create_signed_download_url_expires_in_7_days(mock_get_s3_client: mock.M
         ExpiresIn=604800,  # 7 days in seconds
     )
     assert result == "https://example.com/signed-download-url"
+
+
+# ---------------------------------------------------------------------------
+# find() — server-side prefix optimisation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@mock.patch("aignostics.bucket._service.Service._get_s3_client")
+def test_find_exact_key_passes_prefix_to_paginator(mock_get_s3_client: mock.MagicMock) -> None:
+    """find() with a single exact key passes that key as the S3 Prefix parameter."""
+    path_to_file = "path/to/file.txt"
+    service, mock_paginator = _setup_find(
+        mock_get_s3_client,
+        [_make_page([path_to_file])],
+    )
+
+    result = service.find([path_to_file], what_is_key=True)
+
+    mock_paginator.paginate.assert_called_once_with(Bucket="test-bucket", Prefix=path_to_file)
+    assert result == [path_to_file]
+
+
+@pytest.mark.unit
+@mock.patch("aignostics.bucket._service.Service._get_s3_client")
+def test_find_multiple_exact_keys_uses_common_prefix(mock_get_s3_client: mock.MagicMock) -> None:
+    """find() with multiple exact keys derives their longest common prefix for S3."""
+    path_to_a = "path/to/a.txt"
+    path_to_b = "path/to/b.txt"
+    service, mock_paginator = _setup_find(
+        mock_get_s3_client,
+        [_make_page([path_to_a, path_to_b])],
+    )
+
+    result = service.find([path_to_a, path_to_b], what_is_key=True)
+
+    mock_paginator.paginate.assert_called_once_with(Bucket="test-bucket", Prefix="path/to/")
+    assert set(result) == {path_to_a, path_to_b}
+
+
+@pytest.mark.unit
+@mock.patch("aignostics.bucket._service.Service._get_s3_client")
+def test_find_exact_keys_no_common_prefix_scans_full_bucket(mock_get_s3_client: mock.MagicMock) -> None:
+    """find() with keys that share no prefix performs a full-bucket scan (no Prefix kwarg)."""
+    service, mock_paginator = _setup_find(
+        mock_get_s3_client,
+        [_make_page(["alpha/x", "beta/y"])],
+    )
+
+    service.find(["alpha/x", "beta/y"], what_is_key=True)
+
+    call_kwargs = mock_paginator.paginate.call_args.kwargs
+    assert "Prefix" not in call_kwargs
+    assert call_kwargs["Bucket"] == "test-bucket"
+
+
+@pytest.mark.unit
+@mock.patch("aignostics.bucket._service.Service._get_s3_client")
+def test_find_regex_with_literal_prefix(mock_get_s3_client: mock.MagicMock) -> None:
+    """find() extracts the literal portion of a regex pattern and passes it as Prefix."""
+    service, mock_paginator = _setup_find(
+        mock_get_s3_client,
+        [_make_page(["runner/test/abc/result.json"])],
+    )
+
+    result = service.find(["runner/test/abc/.*"])
+
+    mock_paginator.paginate.assert_called_once_with(Bucket="test-bucket", Prefix="runner/test/abc/")
+    assert result == ["runner/test/abc/result.json"]
+
+
+@pytest.mark.unit
+@mock.patch("aignostics.bucket._service.Service._get_s3_client")
+def test_find_regex_starting_with_metachar_scans_full_bucket(mock_get_s3_client: mock.MagicMock) -> None:
+    """find() with a regex starting with a metacharacter performs a full-bucket scan."""
+    service, mock_paginator = _setup_find(
+        mock_get_s3_client,
+        [_make_page(["special/object.txt"])],
+    )
+
+    result = service.find([".*special.*"])
+
+    call_kwargs = mock_paginator.paginate.call_args.kwargs
+    assert "Prefix" not in call_kwargs
+    assert result == ["special/object.txt"]
+
+
+@pytest.mark.unit
+@mock.patch("aignostics.bucket._service.Service._get_s3_client")
+def test_find_multiple_regex_uses_common_literal_prefix(mock_get_s3_client: mock.MagicMock) -> None:
+    """find() computes the common literal prefix across multiple regex patterns."""
+    service, mock_paginator = _setup_find(
+        mock_get_s3_client,
+        [_make_page(["path/to/a_file.txt", "path/to/b_file.txt"])],
+    )
+
+    service.find(["path/to/a.*", "path/to/b.*"])
+
+    mock_paginator.paginate.assert_called_once_with(Bucket="test-bucket", Prefix="path/to/")
+
+
+@pytest.mark.unit
+@mock.patch("aignostics.bucket._service.Service._get_s3_client")
+def test_find_default_none_scans_full_bucket(mock_get_s3_client: mock.MagicMock) -> None:
+    """find(None) defaults to '.*' which carries no useful prefix — full-bucket scan."""
+    service, mock_paginator = _setup_find(
+        mock_get_s3_client,
+        [_make_page(["any/object.txt"])],
+    )
+
+    service.find(None)
+
+    call_kwargs = mock_paginator.paginate.call_args.kwargs
+    assert "Prefix" not in call_kwargs
+    assert call_kwargs["Bucket"] == "test-bucket"
+
+
+@pytest.mark.unit
+@mock.patch("aignostics.bucket._service.Service._get_s3_client")
+def test_find_returns_detailed_results_when_requested(mock_get_s3_client: mock.MagicMock) -> None:
+    """find() with detail=True returns dicts containing key, size, size_human, etc."""
+    path_to_file = "path/to/file.txt"
+    service, _ = _setup_find(
+        mock_get_s3_client,
+        [_make_page([path_to_file])],
+    )
+
+    result = service.find([path_to_file], what_is_key=True, detail=True)
+
+    assert len(result) == 1
+    item = result[0]
+    assert isinstance(item, dict)
+    assert item["key"] == path_to_file
+    assert item["size"] == 1024
+    assert "size_human" in item
+    assert "etag" in item
+    assert "storage_class" in item
+
+
+@pytest.mark.unit
+@mock.patch("aignostics.bucket._service.Service._get_s3_client")
+def test_find_filters_correctly_with_prefix_and_extra_objects(mock_get_s3_client: mock.MagicMock) -> None:
+    """Client-side filtering still excludes non-matching keys returned under the S3 prefix."""
+    path_to_file = "path/to/match.txt"
+    service, _ = _setup_find(
+        mock_get_s3_client,
+        # The mock page returns two objects under the prefix — only one matches the requested key.
+        [_make_page([path_to_file, "path/to/other.txt"])],
+    )
+
+    result = service.find([path_to_file], what_is_key=True)
+
+    assert result == [path_to_file]


### PR DESCRIPTION
A bunch of mostly atomic changes to make tests more reliable.

## 6887f2a836b80d9abe74454b3d76cfc3dc83bd3d
Extends two tests to create their own runs before updating run / item custom metadata respectively
* This prevents race conditions between parallel test runs
* The runs are cancelled at the end of the test and submitted with a 5m deadline in case cancellation fails
* The tests now run on all runners, since race conditions cannot happen anymore

## 16ba23561268c6e8c9245ec1941e27e62c394aa8
Adds a retry mechanism when checking that a run was cancelled
* This prevents failures caused by the delay between cancelling a run and SAMIA reporting that run as cancelled
* I'm also increasing the timeout since the underlying API calls with built-in Python SDK retries can easily extend beyond 60s

## aabfe811502a463912d6628f72c43c2d090502dc
Optimises the `BucketService.find()` method by passing a prefix to the underlying paginator when possible
* This avoids full scans on the bucket
* Client-side filtering is preserved
* When `find()` is given a regex which cannot be translated to a prefix, we still do a full scan and fall back on client-side filtering
* Previously `test_cli_bucket_flow` regularly timed out after 15m on the `macos-latest` runner, with this change it succeeds in ~5m

## c5d6d42119dd44780cdaf3c32c4c935248f69d3e
Follow-up to the previous commit where I refactor `find()` to make SonarCloud happy

## 9d3131b646362526f11ac948c766b8b9b6be0877
Fixes the noxfile so that sequential tests run even when non-sequential tests fail
* Previously when non-sequential tests failed the nox function failed before running sequential tests, resulting in a drop in reported code coverage

## ce6595d845c3b9242534e9363d49d0c734fb18b1
Updates the pre-commit to only run `make lint` - previously it implicitly ran `make all` which runs linter, all tests, etc
* Even running just the unit tests is too slow to have in pre-commit IMO, and not strictly necessary since we run them in CI

## ef29ba72e84bc2688683857be34c971f513ddd5d
Adds retries to requests in the `IDCClient`
* Includes a comment about the modification as per our OSS use policy