### PR TITLE
fix(platform): use dedicated HTTP pool for authenticated health check

### DIFF
--- a/src/aignostics/platform/_service.py
+++ b/src/aignostics/platform/_service.py
@@ -205,7 +205,7 @@ class Service(BaseService):
             http = self._get_http_pool()
             response = http.request(
                 method="GET",
-                url=f"{self._settings.api_root}/api/v1/health",
+                url=f"{self._settings.api_root}/health",
                 headers={"User-Agent": user_agent()},
                 timeout=urllib3.Timeout(total=self._settings.health_timeout),
             )

--- a/src/aignostics/platform/_service.py
+++ b/src/aignostics/platform/_service.py
@@ -222,21 +222,27 @@ class Service(BaseService):
         return Health(status=Health.Code.UP)
 
     def _determine_api_authenticated_health(self) -> Health:
-        """Determine healthiness and reachability of Aignostics Platform API via authenticated API client.
+        """Determine healthiness and reachability of Aignostics Platform API via authenticated request.
 
-        - Checks if health endpoint is reachable and returns 200 OK
+        Uses a dedicated HTTP pool (separate from the API client's connection pool) to prevent
+        connection-level cross-contamination between health checks and API calls.
 
         Returns:
-            Health: The healthiness of the Aignostics Platform API when trying to reach via authenticated API client.
+            Health: The healthiness of the Aignostics Platform API when trying to reach via authenticated request.
         """
         try:
-            api_client = Client.get_api_client(cache_token=True).api_client
-            response = api_client.call_api(
-                url=self._settings.api_root + "/api/v1/health",
+            token = get_token(use_cache=True)
+            http = self._get_http_pool()
+            response = http.request(
                 method="GET",
-                header_params={"User-Agent": user_agent()},
-                _request_timeout=self._settings.health_timeout,
+                url=f"{self._settings.api_root}/health",
+                headers={
+                    "User-Agent": user_agent(),
+                    "Authorization": f"Bearer {token}",
+                },
+                timeout=urllib3.Timeout(total=self._settings.health_timeout),
             )
+
             if response.status != HTTPStatus.OK:
                 logger.error("Aignostics Platform API (authenticated) returned '{}'", response.status)
                 return Health(status=Health.Code.DOWN, reason=f"Aignostics Platform API returned '{response.status}'")

--- a/tests/aignostics/platform/conftest.py
+++ b/tests/aignostics/platform/conftest.py
@@ -7,6 +7,7 @@ import pytest
 
 from aignostics.platform._client import Client
 from aignostics.platform._operation_cache import _operation_cache
+from aignostics.platform._service import Service
 
 
 @pytest.fixture
@@ -54,12 +55,21 @@ def mock_api_client() -> MagicMock:
 
 
 @pytest.fixture(autouse=True)
-def clear_cache() -> None:
-    """Clear the operation cache before each test.
+def clear_cache() -> t.Generator[None, None, None]:
+    """Clear the operation cache and API client singletons before and after each test.
 
-    This ensures tests don't interfere with each other through shared cache state.
+    This ensures tests don't interfere with each other through shared cache state
+    or shared urllib3 connection pools (which could cause response cross-contamination).
     """
     _operation_cache.clear()
+    Client._api_client_cached = None
+    Client._api_client_uncached = None
+    Service._http_pool = None
+    yield
+    _operation_cache.clear()
+    Client._api_client_cached = None
+    Client._api_client_uncached = None
+    Service._http_pool = None
 
 
 @pytest.fixture

--- a/tests/aignostics/platform/service_test.py
+++ b/tests/aignostics/platform/service_test.py
@@ -1,10 +1,14 @@
 """Tests for the platform service module."""
 
-from unittest.mock import MagicMock
+from http import HTTPStatus
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from aignostics.platform._service import Service, UserInfo
+from aignostics.utils import Health
+
+_PATCH_AUTH_GETTER = "aignostics.platform._service.get_token"
 
 
 @pytest.mark.unit
@@ -40,6 +44,117 @@ def test_http_pool_singleton() -> None:
 
     # Verify they share the same pool
     assert pool_from_service1 is pool_from_service2, "Service instances should share the same HTTP pool"
+
+
+@pytest.mark.unit
+def test_determine_api_authenticated_health_success() -> None:
+    """Health.UP returned when the dedicated pool responds 200 with auth token."""
+    mock_response = MagicMock()
+    mock_response.status = HTTPStatus.OK
+
+    mock_pool = MagicMock()
+    mock_pool.request.return_value = mock_response
+
+    with (
+        patch.object(Service, "_get_http_pool", return_value=mock_pool),
+        patch(_PATCH_AUTH_GETTER, return_value="test-token"),
+    ):
+        result = Service()._determine_api_authenticated_health()
+
+    assert result.status == Health.Code.UP
+
+
+@pytest.mark.unit
+def test_determine_api_authenticated_health_non_200() -> None:
+    """Health.DOWN returned when the dedicated pool responds with non-200."""
+    mock_response = MagicMock()
+    mock_response.status = HTTPStatus.SERVICE_UNAVAILABLE
+
+    mock_pool = MagicMock()
+    mock_pool.request.return_value = mock_response
+
+    with (
+        patch.object(Service, "_get_http_pool", return_value=mock_pool),
+        patch(_PATCH_AUTH_GETTER, return_value="test-token"),
+    ):
+        result = Service()._determine_api_authenticated_health()
+
+    assert result.status == Health.Code.DOWN
+    assert result.reason is not None
+
+
+@pytest.mark.unit
+def test_determine_api_authenticated_health_handles_exception() -> None:
+    """Health.DOWN with reason when get_token raises."""
+    with patch(_PATCH_AUTH_GETTER, side_effect=RuntimeError("no auth")):
+        result = Service()._determine_api_authenticated_health()
+
+    assert result.status == Health.Code.DOWN
+    assert result.reason is not None
+
+
+@pytest.mark.unit
+def test_determine_api_public_health_success() -> None:
+    """Health.UP returned when the public pool responds 200."""
+    mock_response = MagicMock()
+    mock_response.status = HTTPStatus.OK
+
+    mock_pool = MagicMock()
+    mock_pool.request.return_value = mock_response
+
+    with patch.object(Service, "_get_http_pool", return_value=mock_pool):
+        result = Service()._determine_api_public_health()
+
+    assert result.status == Health.Code.UP
+
+
+@pytest.mark.unit
+def test_determine_api_public_health_non_200() -> None:
+    """Health.DOWN returned when the public pool responds with non-200."""
+    mock_response = MagicMock()
+    mock_response.status = HTTPStatus.SERVICE_UNAVAILABLE
+
+    mock_pool = MagicMock()
+    mock_pool.request.return_value = mock_response
+
+    with patch.object(Service, "_get_http_pool", return_value=mock_pool):
+        result = Service()._determine_api_public_health()
+
+    assert result.status == Health.Code.DOWN
+    assert result.reason is not None
+
+
+@pytest.mark.unit
+def test_determine_api_public_health_handles_exception() -> None:
+    """Health.DOWN returned when the public pool raises."""
+    mock_pool = MagicMock()
+    mock_pool.request.side_effect = ConnectionError("unreachable")
+
+    with patch.object(Service, "_get_http_pool", return_value=mock_pool):
+        result = Service()._determine_api_public_health()
+
+    assert result.status == Health.Code.DOWN
+    assert result.reason is not None
+
+
+@pytest.mark.unit
+def test_health_returns_both_components() -> None:
+    """health() aggregates api_public and api_authenticated component keys."""
+    public_health = Health(status=Health.Code.UP)
+    auth_health = Health(status=Health.Code.UP)
+
+    service = Service()
+    with (
+        patch.object(service, "_determine_api_public_health", return_value=public_health),
+        patch.object(service, "_determine_api_authenticated_health", return_value=auth_health),
+    ):
+        result = service.health()
+
+    assert result.components is not None
+    assert "api_public" in result.components
+    assert "api_authenticated" in result.components
+    assert result.components["api_public"] is public_health
+    assert result.components["api_authenticated"] is auth_health
 
 
 @pytest.mark.unit

--- a/tests/aignostics/qupath/cli_test.py
+++ b/tests/aignostics/qupath/cli_test.py
@@ -137,7 +137,7 @@ def test_cli_install_launch_project_annotations_headless(runner: CliRunner, tmpd
     platform.system() == "Linux" and platform.machine() in {"aarch64", "arm64"},
     reason="QuPath is not supported on ARM64 Linux",
 )
-@pytest.mark.flaky(retries=1, delay=5, only_on=[AssertionError])
+@pytest.mark.flaky(retries=3, delay=5, only_on=[AssertionError])
 @pytest.mark.timeout(timeout=60 * 10)
 @pytest.mark.sequential
 def test_cli_install_and_launch_ui(runner: CliRunner, qupath_teardown) -> None:


### PR DESCRIPTION
One test (`test_login_out_info_e2e`) repeatedly fails because of an invalid response from the API. This looks like the response from a previous call leaking into the later response. The exact cause could not be identified, however we don't observe the issue anymore after switching to a dedicated HTTP pool rather than using the shared API client. This was never observed outside of that specific test.

Also switching the platform health check to the correct `/health` endpoint, and increasing retries for the flaky QuPath test.