### PR TITLE
chore: update Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
+  "extends": ["config:recommended"],
   "timezone": "Europe/Berlin",
-  "schedule": "before 2am every weekday",
+  "schedule": ["at any time"],
   "labels": [
     "bot",
     "renovate",
@@ -12,7 +10,20 @@
     "skip:test:long_running",
     "skip:codecov"
   ],
-  "ignorePaths": [
-    "plugins/manifest/package.json"
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 5am on monday"]
+  },
+  "packageRules": [
+    {
+      "groupName": "minor and patch dependencies",
+      "matchManagers": ["pep621"],
+      "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "groupName": "GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "separateMajorMinor": false
+    }
   ]
 }


### PR DESCRIPTION
* Run at any time to avoid "updates are awaiting their schedule" forever
* Enable lock file maintenance
* Group all updates to GitHub Actions (major/minor/patch); group minor/patch updates to Python dependencies