### PR TITLE
test: mock BucketService.find_static in GUI test

### DIFF
--- a/tests/aignostics/bucket/gui_test.py
+++ b/tests/aignostics/bucket/gui_test.py
@@ -5,6 +5,7 @@ import random
 import string
 from asyncio import sleep
 from pathlib import Path
+from unittest.mock import patch
 
 import psutil
 import pytest
@@ -18,8 +19,10 @@ from tests.conftest import assert_notified
 @pytest.mark.integration
 async def test_gui_bucket_shows(user: User) -> None:
     """Test that the user sees the dataset page."""
-    await user.open("/bucket")
-    await user.should_see("The bucket is securely hosted on Google Cloud in EU")
+    # Service.find_static can be slow and lead to test timeouts; we patch it to return an empty list.
+    with patch("aignostics.bucket._gui.Service.find_static", return_value=[]):
+        await user.open("/bucket")
+        await user.should_see("The bucket is securely hosted on Google Cloud in EU")
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
`test_gui_bucket_shows` sometimes exceeds the 10s pytest timeout. Most of that is spent in the teardown phase (observed up to 9s). The hypothesis is that `user.open("/bucket")` calls `_get_rows()` which runs `Service.find_static` in a thread; the test immediately succeeds because the test user sees the expected message, but listing the files in the bucket is still running in the background. The teardown lasts until this listing operation ends, which sometimes pushes it over the 10s timeout. I fix this by patching the `find_static` method to return an empty list.

Observed teardown time before: 8-9s
Observed teardown time after: 2-3s