### PR TITLE
chore: run all tests even on failure

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -158,7 +158,17 @@ jobs:
           uv run --all-extras aignostics application list
           uv run --all-extras aignostics application run list --verbose --limit 1
 
+      # All test steps use continue-on-error: true so that every test suite
+      # always runs regardless of whether earlier suites failed. This ensures
+      # Codecov always receives a complete coverage report (partial reports
+      # cause the coverage badge to read lower than the true value).
+      # A single "Assert no test failures" gate step at the end surfaces any
+      # failures and fails the job — so the workflow still fails correctly.
+
       - name: Test / Unit (multiple Python versions)
+        id: unit
+        continue-on-error: true
+        if: ${{ !cancelled() }}
         uses: ./.github/actions/run-tests
         with:
           test-type: unit
@@ -168,6 +178,9 @@ jobs:
           commit-message: ${{ inputs.commit_message }}
 
       - name: Test / Integration (multiple Python versions)
+        id: integration
+        continue-on-error: true
+        if: ${{ !cancelled() }}
         uses: ./.github/actions/run-tests
         with:
           test-type: integration
@@ -177,6 +190,9 @@ jobs:
           commit-message: ${{ inputs.commit_message }}
 
       - name: Test / E2E / regular (multiple Python versions)
+        id: e2e
+        continue-on-error: true
+        if: ${{ !cancelled() }}
         uses: ./.github/actions/run-tests
         with:
           test-type: e2e
@@ -186,6 +202,9 @@ jobs:
           commit-message: ${{ inputs.commit_message }}
 
       - name: Test / E2E / long running (single Python version)
+        id: long_running
+        continue-on-error: true
+        if: ${{ !cancelled() }}
         uses: ./.github/actions/run-tests
         with:
           test-type: long-running
@@ -195,9 +214,13 @@ jobs:
           commit-message: ${{ inputs.commit_message }}
 
       - name: Test / E2E / very long running (single Python version)
+        id: very_long_running
+        continue-on-error: true
         if: |
-          contains(inputs.commit_message, 'enable:test:very_long_running') || 
-          contains(github.event.pull_request.labels.*.name, 'enable:test:very_long_running')
+          !cancelled() && (
+            contains(inputs.commit_message, 'enable:test:very_long_running') ||
+            contains(github.event.pull_request.labels.*.name, 'enable:test:very_long_running')
+          )
         uses: ./.github/actions/run-tests
         with:
           test-type: very-long-running
@@ -247,3 +270,22 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
+      - name: Assert no test failures
+        # Single gate that fails the job if any test suite failed. Kept last so
+        # that all reporting steps (Codecov, SonarQube, artifact upload) always
+        # run to completion before the job is marked as failed.
+        if: ${{ !cancelled() }}
+        shell: bash
+        run: |
+          failed=()
+          [[ "${{ steps.unit.outcome }}"              == "failure" ]] && failed+=("unit")
+          [[ "${{ steps.integration.outcome }}"       == "failure" ]] && failed+=("integration")
+          [[ "${{ steps.e2e.outcome }}"               == "failure" ]] && failed+=("e2e")
+          [[ "${{ steps.long_running.outcome }}"      == "failure" ]] && failed+=("long-running")
+          [[ "${{ steps.very_long_running.outcome }}" == "failure" ]] && failed+=("very-long-running")
+          if [[ ${#failed[@]} -gt 0 ]]; then
+            echo "The following test suites failed: ${failed[*]}"
+            exit 1
+          fi
+          echo "All test suites passed."


### PR DESCRIPTION
Currently if one test suite fails, the following suites never run (e.g. if integration fails we never run E2E regular + long-running). This leads to under-reported code coverage.

Instead, we now run all tests regardless of whether the previous suite failed and then catch all failures in a single step.