### PR TITLE
fix: system health exits with 0 when degraded

### DIFF
--- a/src/aignostics/system/_cli.py
+++ b/src/aignostics/system/_cli.py
@@ -11,7 +11,7 @@ import typer
 import yaml
 
 from ..constants import API_VERSIONS  # noqa: TID252
-from ..utils import Health, console  # noqa: TID252
+from ..utils import console  # noqa: TID252
 from ._service import Service
 
 cli = typer.Typer(name="system", help="Determine health, info and further utillities.")
@@ -60,7 +60,7 @@ def health(
                 yaml.dump(data=json.loads(health.model_dump_json()), width=80, default_flow_style=False),
                 end="",
             )
-    if health.status is not Health.Code.UP:
+    if not health:
         sys.exit(1)
 
 

--- a/tests/aignostics/system/cli_test.py
+++ b/tests/aignostics/system/cli_test.py
@@ -84,6 +84,39 @@ def test_cli_info_secrets(runner: CliRunner, caplog: pytest.LogCaptureFixture, r
         assert secret_found, "Expected secret value to be present in unmasked output, but it was not found"
 
 
+@pytest.mark.unit
+@patch("aignostics.system._cli._service")
+def test_cli_health_up_exits_zero(mock_service: MagicMock, runner: CliRunner) -> None:
+    """Check health command exits with code 0 when status is UP."""
+    from aignostics.utils import Health
+
+    mock_service.health.return_value = Health(status=Health.Code.UP)
+    result = runner.invoke(cli, ["system", "health"])
+    assert result.exit_code == 0
+
+
+@pytest.mark.unit
+@patch("aignostics.system._cli._service")
+def test_cli_health_degraded_exits_zero(mock_service: MagicMock, runner: CliRunner) -> None:
+    """Check health command exits with code 0 when status is DEGRADED."""
+    from aignostics.utils import Health
+
+    mock_service.health.return_value = Health(status=Health.Code.DEGRADED, reason="some component degraded")
+    result = runner.invoke(cli, ["system", "health"])
+    assert result.exit_code == 0
+
+
+@pytest.mark.unit
+@patch("aignostics.system._cli._service")
+def test_cli_health_down_exits_one(mock_service: MagicMock, runner: CliRunner) -> None:
+    """Check health command exits with code 1 when status is DOWN."""
+    from aignostics.utils import Health
+
+    mock_service.health.return_value = Health(status=Health.Code.DOWN, reason="service unavailable")
+    result = runner.invoke(cli, ["system", "health"])
+    assert result.exit_code == 1
+
+
 @pytest.mark.integration
 @patch("aignostics.utils._gui.gui_register_pages")
 @patch("nicegui.ui.run")


### PR DESCRIPTION
`system health` should return 0 when the system is UP or DEGRADED; 1 when DOWN.