### PR TITLE
chore: run SonarCloud analysis immediately on PRs

### DIFF
--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -27,8 +27,6 @@ on:
         required: false
       CODECOV_TOKEN:
         required: false
-      SONAR_TOKEN:
-        required: false
       SENTRY_DSN:
         required: false
   
@@ -263,13 +261,6 @@ jobs:
         uses: codecov/test-results-action@0fa95f0e1eeaafde2c782583b36b28ad0d8c77d3 # v1.2.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: SonarQube Scan
-        if: ${{ !cancelled() && (env.GITHUB_WORKFLOW_RUNTIME != 'ACT') && matrix.runner == 'ubuntu-latest' }}
-        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 
       - name: Assert no test failures
         # Single gate that fails the job if any test suite failed. Kept last so

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -112,7 +112,6 @@ jobs:
       AIGNOSTICS_REFRESH_TOKEN_PRODUCTION: ${{ secrets.AIGNOSTICS_REFRESH_TOKEN_PRODUCTION }}
       GCP_CREDENTIALS_PRODUCTION: ${{ secrets.GCP_CREDENTIALS_PRODUCTION }}
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
       SENTRY_DSN: ${{ secrets.SENTRY_DSN }} # For metrics
 
   codeql:
@@ -130,8 +129,34 @@ jobs:
       packages: read
       security-events: write
 
+  sonarcloud:
+    needs: [get-commit-message]
+    if: |
+      (!contains(needs.get-commit-message.outputs.commit_message, 'skip:ci')) &&
+      (!contains(needs.get-commit-message.outputs.commit_message, 'build:native:only')) &&
+      !(github.ref_type == 'branch' && startsWith(needs.get-commit-message.outputs.commit_message, 'Bump version:')) &&
+      (!contains(github.event.pull_request.labels.*.name, 'skip:ci')) &&
+      (!contains(github.event.pull_request.labels.*.name, 'build:native:only'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+
+      - name: SonarQube Scan
+        if: ${{ env.GITHUB_WORKFLOW_RUNTIME != 'ACT' }}
+        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 # v7.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+
   ketryx_report_and_check:
-    needs: [get-commit-message, lint, audit, test, codeql]
+    needs: [get-commit-message, lint, audit, test, codeql, sonarcloud]
     if: |
       github.actor != 'dependabot[bot]' &&
       (!contains(needs.get-commit-message.outputs.commit_message, 'skip:ci')) &&

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,7 +6,6 @@ sonar.links.homepage=https://aignostics.readthedocs.io/en/latest/
 sonar.links.scm=https://github.com/aignostics/python-sdk
 sonar.links.ci=https://github.com/aignostics/python-sdk/actions
 sonar.links.issues=https://github.com/aignostics/python-sdk/issues
-sonar.python.coverage.reportPaths=reports/coverage.xml
 sonar.python.version=3.11, 3.12, 3.13
 sonar.coverage.exclusions=noxfile.py, template/**, tests/**, examples/**, docs/**, dist/**, dist_vercel/**, dist_native/**, **/third_party/**, codegen/**, **/_notebook.py, **/_pydicom_handler.py, **/_openslide_handler.py
 sonar.exclusions=template/**, examples/**, docs/**, dist/**, dist_vercel/**, dist_native/**, **/third_party/**, codegen/**, **/_notebook.py


### PR DESCRIPTION
We use CodeCov for coverage checks, therefore SonarCloud does not need to wait until tests have finished to run.