### PR TITLE
test: update brittle tests

### DIFF
--- a/tests/aignostics/application/cli_test.py
+++ b/tests/aignostics/application/cli_test.py
@@ -310,7 +310,7 @@ def test_cli_run_submit_fails_when_system_unhealthy_and_no_force(
 
 
 @pytest.mark.e2e
-@pytest.mark.timeout(timeout=10)
+@pytest.mark.timeout(timeout=60)
 @patch("aignostics.application._cli.SystemService.health_static")
 def test_cli_run_submit_succeeds_when_system_degraded_and_no_force(
     mock_health: MagicMock, runner: CliRunner, tmp_path: Path

--- a/tests/aignostics/system/cli_test.py
+++ b/tests/aignostics/system/cli_test.py
@@ -15,25 +15,53 @@ from tests.conftest import normalize_output
 THE_VALUE = "test_secret_value_not_real_for_testing_only"
 
 
+@pytest.mark.unit
+@patch("aignostics.system._cli._service")
+def test_cli_health_json_format(mock_service: MagicMock, runner: CliRunner, record_property) -> None:
+    """Check health CLI renders UP status correctly as JSON."""
+    record_property("tested-item-id", "TEST-SYSTEM-CLI-HEALTH-JSON")
+    from aignostics.utils import Health
+
+    mock_service.health.return_value = Health(status=Health.Code.UP)
+    result = runner.invoke(cli, ["system", "health"])
+    assert result.exit_code == 0
+    assert normalize_output(result.stdout).startswith('{  "status": "UP"')
+
+
+@pytest.mark.unit
+@patch("aignostics.system._cli._service")
+def test_cli_health_yaml_format(mock_service: MagicMock, runner: CliRunner, record_property) -> None:
+    """Check health CLI renders UP status correctly as YAML."""
+    record_property("tested-item-id", "TEST-SYSTEM-CLI-HEALTH-YAML")
+    from aignostics.utils import Health
+
+    mock_service.health.return_value = Health(status=Health.Code.UP)
+    result = runner.invoke(cli, ["system", "health", "--output-format", "yaml"])
+    assert result.exit_code == 0
+    assert "status: UP" in result.stdout
+
+
 @pytest.mark.e2e
 @pytest.mark.scheduled
 @pytest.mark.timeout(timeout=60)
-def test_cli_health_json(runner: CliRunner, record_property) -> None:
-    """Check health is true."""
-    record_property("tested-item-id", "TEST-SYSTEM-CLI-HEALTH-JSON")
+def test_cli_health_json(runner: CliRunner) -> None:
+    """Check health CLI returns valid JSON with a valid status value."""
+    import json
+
     result = runner.invoke(cli, ["system", "health"])
-    assert normalize_output(result.stdout).startswith('{  "status": "UP"')
-    assert result.exit_code == 0
+    data = json.loads(result.stdout)
+    assert data["status"] in {"UP", "DEGRADED", "DOWN"}
 
 
 @pytest.mark.e2e
 @pytest.mark.timeout(timeout=30)
-def test_cli_health_yaml(runner: CliRunner, record_property) -> None:
-    """Check health is true."""
-    record_property("tested-item-id", "TEST-SYSTEM-CLI-HEALTH-YAML")
+def test_cli_health_yaml(runner: CliRunner) -> None:
+    """Check health CLI returns valid YAML with a valid status value."""
+    import yaml
+
     result = runner.invoke(cli, ["system", "health", "--output-format", "yaml"])
-    assert "status: UP" in result.stdout
-    assert result.exit_code == 0
+    data = yaml.safe_load(result.stdout)
+    assert data["status"] in {"UP", "DEGRADED", "DOWN"}
 
 
 @pytest.mark.e2e


### PR DESCRIPTION
Increasing the timeout for `test_cli_run_submit_succeeds_when_system_degraded_and_no_force` since submitting + cancelling a run can push it beyond 10s.

Also updating the CLI health tests: `test_cli_health_json` and `test_cli_health_yaml` were flakey, as they failed when the platform is degraded/down. I propose the following changes:
* Add 2 unit tests `test_cli_health_json_format` and `test_cli_health_yaml_format` which test the `TEST-SYSTEM-CLI-HEALTH-JSON` and `TEST-SYSTEM-CLI-HEALTH-YAML` scenarios respectively (i.e. when platform is healthy, health command shows UP)
* Update the existing e2e tests `test_cli_health_json` and `test_cli_health_yaml` to assert that the output shows a health state, without specifying which state they should show