### PR TITLE
chore: update renovate schedule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "config:recommended"
   ],
   "timezone": "Europe/Berlin",
-  "schedule": ["at any time"],
+  "schedule": ["* 0-5 * * *"],
   "labels": [
     "bot",
     "renovate",


### PR DESCRIPTION
Currently Renovate rebases its PRs several times a day, which causes concurrent CI runs.

This does not avoid the concurrent CI run issue, but it should prevent it from happening several times during the day.