### PR TITLE
build: Decrease renovate noise

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,10 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ],
+  "extends": ["config:recommended"],
   "timezone": "Europe/Berlin",
   "schedule": ["* 0-5 * * *"],
+  "minimumReleaseAge": "14 days",
+  "internalChecksFilter": "strict",
   "labels": [
     "bot",
     "renovate",
@@ -27,6 +27,28 @@
       "groupName": "GitHub Actions",
       "matchManagers": ["github-actions"],
       "separateMajorMinor": false
+    },
+    {
+      "description": "Bypass delay for security tools",
+      "matchPackageNames": [
+        "trivy",
+        "pip-audit",
+        "aquasecurity/trivy-action",
+        "pypa/pip-audit"
+      ],
+      "minimumReleaseAge": null,
+      "automerge": true,
+      "automergeType": "pr",
+      "schedule": ["at any time"],
+      "groupName": "security-tool-updates"
+    },
+    {
+      "matchVulnerabilities": true,
+      "minimumReleaseAge": null,
+      "automerge": true,
+      "automergeType": "pr",
+      "schedule": ["at any time"],
+      "groupName": "security fixes"
     }
   ]
 }


### PR DESCRIPTION
Currently, renovate aggressively creates MRs in our repos, potentially pulling malicious dependencies from open source componentes before they may be spottet by the community (supply chain attacks). Furthermore, they are causing a lot of noise in our inboxes. This change introduces the following changes:

* updates must be at least 2 weeks old
* unless they fix a known vulnerability
* pull requests are only opened once the change has passed the internal checks