### PR TITLE
fix: upgrade NiceGUI to 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ dependencies = [
     # From Template
     "fastapi[all,standard]>=0.123.10",
     "humanize>=4.14.0,<5",
-    "nicegui[native]>=3.5.0,<4",  # CVE-2026-21871, CVE-2026-21871, CVE-2026-21873, CVE-2026-21874 all require >=3.5.0
+    "nicegui[native]>=3.10.0,<4",  # CVE-2026-39844
     "packaging>=25.0,<26",
     "platformdirs>=4.5.1,<5",
     "psutil>=7.1.3,<8",

--- a/tests/aignostics/notebook/service_test.py
+++ b/tests/aignostics/notebook/service_test.py
@@ -6,8 +6,6 @@ import re
 from unittest.mock import MagicMock, patch
 
 import pytest
-from fastapi.testclient import TestClient
-from nicegui import app
 from nicegui.testing import User
 
 from aignostics.notebook._service import MARIMO_SERVER_STARTUP_TIMEOUT, Service, _get_runner, _Runner
@@ -99,7 +97,7 @@ def test_notebook_start_and_stop(caplog: pytest.LogCaptureFixture) -> None:
 @pytest.mark.flaky(retries=1, delay=5, only_on=[AssertionError])
 @pytest.mark.sequential
 @pytest.mark.timeout(timeout=60 * 2)
-def test_serve_notebook(user: User, caplog: pytest.LogCaptureFixture) -> None:
+async def test_serve_notebook(user: User, caplog: pytest.LogCaptureFixture) -> None:
     """Test notebook serving.
 
     Args:
@@ -112,10 +110,8 @@ def test_serve_notebook(user: User, caplog: pytest.LogCaptureFixture) -> None:
     # Set up logging to capture DEBUG level and above
     caplog.set_level(logging.DEBUG)
 
-    client = TestClient(app)
-
     try:
-        response = client.get("/notebook/4711?results_folder=/tmp", timeout=60)
+        response = await user.http_client.get("/notebook/4711?results_folder=/tmp", follow_redirects=True)
         assert response.status_code == 200
         content = response.content.decode("utf-8")
         assert "iframe" in content

--- a/uv.lock
+++ b/uv.lock
@@ -190,7 +190,7 @@ requires-dist = [
     { name = "marimo", marker = "extra == 'marimo'", specifier = ">=0.18.4,<1" },
     { name = "marshmallow", specifier = ">=3.26.2" },
     { name = "matplotlib", marker = "extra == 'marimo'", specifier = ">=3.10.7,<4" },
-    { name = "nicegui", extras = ["native"], specifier = ">=3.5.0,<4" },
+    { name = "nicegui", extras = ["native"], specifier = ">=3.10.0,<4" },
     { name = "openslide-bin", specifier = ">=4.0.0.10,<5" },
     { name = "openslide-python", specifier = ">=1.4.3,<2" },
     { name = "packaging", specifier = ">=25.0,<26" },
@@ -4299,7 +4299,7 @@ wheels = [
 
 [[package]]
 name = "nicegui"
-version = "3.9.0"
+version = "3.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -4325,9 +4325,9 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
     { name = "watchfiles" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d3/38/ed046018db555c34ebc17738284d2f85bf9a544734cd44a87311128619a5/nicegui-3.9.0.tar.gz", hash = "sha256:7ae9046b321d029c438f7cd54a697838ed1962cecb92c622912283c66c8bf8f6", size = 19031869, upload-time = "2026-03-19T09:51:52.247Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d9/df/736d1e17db943d2a8425de22a69284b0374b8ed17efdcde10a5ba6d181f8/nicegui-3.10.0.tar.gz", hash = "sha256:10bca0ed1957c91506e54e02a8d2ad8860777e121fb54bfe59797493ba87ec14", size = 19147081, upload-time = "2026-04-07T09:27:33.09Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/11/f7f911f284ceb1b038c26d6f4833bc86d6583d5280156274fdb79be7dcfe/nicegui-3.9.0-py3-none-any.whl", hash = "sha256:4adfdb87a55e30b7fef05ab782efc030534ae6ad9afa330db856dfbb258e23c9", size = 19613351, upload-time = "2026-03-19T09:51:48.769Z" },
+    { url = "https://files.pythonhosted.org/packages/de/44/73cd2dda7bd46a903751ea3fd93624ac3a97afdfb6a02e0aead6ee4cb0d1/nicegui-3.10.0-py3-none-any.whl", hash = "sha256:0c7f084b1c9036e645ce43727ac354d89214d355dededb25adc3ba2f4d08aaa3", size = 19711706, upload-time = "2026-04-07T09:27:29.203Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
**Why?**
NiceGUI 3.10 patches CVE-2026-39844.

**How?**
The upgrade to 3.10 breaks `tests/aignostics/notebook/service_test.py::test_serve_notebook` because conflicting NiceGUI lifecycle managers. This PR removes `client = TestClient(app)` and uses `user.http_client` instead.