### PR TITLE
fix(system): replace uptime with psutil

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,6 @@ dependencies = [
     "pyyaml>=6.0.3,<7",
     "sentry-sdk>=2.47.0,<3",
     "typer>=0.20.0,<1",
-    "uptime>=3.0.1,<4",
     # Custom
     "boto3>=1.42.4,<2",
     "certifi>=2025.11.12",

--- a/src/aignostics/system/_service.py
+++ b/src/aignostics/system/_service.py
@@ -1,12 +1,14 @@
 """System service."""
 
 import asyncio
+import datetime
 import json
 import os
 import platform
 import re
 import ssl
 import sys
+import time
 import typing as t
 from http import HTTPStatus
 from pathlib import Path
@@ -309,9 +311,9 @@ class Service(BaseService):
             dict[str, Any]: Service configuration.
         """
         import psutil  # noqa: PLC0415
-        from uptime import boottime, uptime  # noqa: PLC0415
 
-        bootdatetime = boottime()
+        boot_ts = psutil.boot_time()
+        bootdatetime = datetime.datetime.fromtimestamp(boot_ts, tz=datetime.UTC)
         vmem = psutil.virtual_memory()
         swap = psutil.swap_memory()
         psutil.cpu_percent(interval=None)  # prime the counter
@@ -378,8 +380,8 @@ class Service(BaseService):
                         "ssl_default_verify_paths": ssl.get_default_verify_paths()._asdict(),
                     },
                     "uptime": {
-                        "seconds": uptime(),
-                        "boottime": bootdatetime.isoformat() if bootdatetime else None,
+                        "seconds": time.time() - boot_ts,
+                        "boottime": bootdatetime.isoformat(),
                     },
                 },
                 "python": {

--- a/tests/aignostics/system/service_test.py
+++ b/tests/aignostics/system/service_test.py
@@ -8,6 +8,72 @@ import pytest
 
 from aignostics.system._service import Service
 
+# ---------------------------------------------------------------------------
+# Helpers shared by uptime tests
+# ---------------------------------------------------------------------------
+
+FIXED_BOOT_TIME = 1_000_000.0  # arbitrary fixed epoch seconds
+
+
+def _make_mock_process() -> mock.MagicMock:
+    proc = mock.MagicMock()
+    proc.username.return_value = "testuser"
+    return proc
+
+
+def _patch_info_dependencies(boot_time: float = FIXED_BOOT_TIME):
+    """Return a context manager stack that patches all external I/O for Service.info()."""
+    import contextlib
+
+    now = boot_time + 3600.0  # pretend system has been up 1 hour
+
+    vmem = mock.MagicMock()
+    vmem.percent = 50.0
+    vmem.total = 8_000_000_000
+    vmem.available = 4_000_000_000
+    vmem.used = 3_500_000_000
+    vmem.free = 500_000_000
+
+    swap = mock.MagicMock()
+    swap.percent = 10.0
+    swap.total = 2_000_000_000
+    swap.used = 200_000_000
+    swap.free = 1_800_000_000
+
+    cpu_times = mock.MagicMock()
+    cpu_times.user = 20.0
+    cpu_times.system = 10.0
+    cpu_times.idle = 70.0
+
+    from aignostics.utils._process import ParentProcessInfo, ProcessInfo
+
+    mock_process_info = ProcessInfo(
+        project_root="/fake/root",
+        pid=1234,
+        parent=ParentProcessInfo(name="pytest", pid=1),
+    )
+
+    @contextlib.contextmanager
+    def _ctx():
+        with (
+            mock.patch("psutil.boot_time", return_value=boot_time),
+            mock.patch("psutil.virtual_memory", return_value=vmem),
+            mock.patch("psutil.swap_memory", return_value=swap),
+            mock.patch("psutil.cpu_percent", return_value=15.0),
+            mock.patch("psutil.cpu_times_percent", return_value=cpu_times),
+            mock.patch("psutil.getloadavg", return_value=(1.0, 1.0, 1.0)),
+            mock.patch("psutil.Process", return_value=_make_mock_process()),
+            mock.patch("aignostics.system._service.get_process_info", return_value=mock_process_info),
+            mock.patch("asyncio.sleep"),
+            mock.patch.object(Service, "_get_public_ipv4", return_value=None),
+            mock.patch.object(Service, "_collect_all_settings", return_value={}),
+            mock.patch("aignostics.system._service.locate_subclasses", return_value=[]),
+            mock.patch("time.time", return_value=now),
+        ):
+            yield
+
+    return _ctx()
+
 
 @pytest.mark.unit
 def test_get_cpu_freq_info_returns_dict_with_expected_keys() -> None:
@@ -397,3 +463,51 @@ def test_is_secret_key_real_world_examples(record_property) -> None:
 
     for key in non_secret_examples:
         assert not Service._is_secret_key(key), f"Expected '{key}' to NOT be identified as a secret key"
+
+
+# ---------------------------------------------------------------------------
+# Uptime tests — verify psutil-based implementation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_info_uptime_keys_present() -> None:
+    """info() uptime dict contains both 'seconds' and 'boottime' keys with non-None values."""
+    with _patch_info_dependencies():
+        result = await Service.info()
+
+    uptime = result["runtime"]["host"]["uptime"]
+    assert "seconds" in uptime
+    assert "boottime" in uptime
+    assert uptime["seconds"] is not None
+    assert uptime["boottime"] is not None
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_info_uptime_seconds_positive() -> None:
+    """info() uptime seconds is a positive number (time since boot)."""
+    with _patch_info_dependencies():
+        result = await Service.info()
+
+    seconds = result["runtime"]["host"]["uptime"]["seconds"]
+    assert isinstance(seconds, float)
+    assert seconds > 0
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+async def test_info_uptime_boottime_is_iso_string() -> None:
+    """info() uptime boottime is a non-empty ISO 8601 string."""
+    import datetime
+
+    with _patch_info_dependencies():
+        result = await Service.info()
+
+    boottime_str = result["runtime"]["host"]["uptime"]["boottime"]
+    assert isinstance(boottime_str, str)
+    assert len(boottime_str) > 0
+    # Must be parseable as an ISO 8601 datetime
+    parsed = datetime.datetime.fromisoformat(boottime_str)
+    assert parsed.tzinfo is not None  # timezone-aware (UTC)

--- a/uv.lock
+++ b/uv.lock
@@ -81,7 +81,6 @@ dependencies = [
     { name = "tqdm" },
     { name = "truststore" },
     { name = "typer" },
-    { name = "uptime" },
     { name = "urllib3" },
     { name = "wsidicom" },
 ]
@@ -222,7 +221,6 @@ requires-dist = [
     { name = "tqdm", specifier = ">=4.67.1,<5" },
     { name = "truststore", specifier = ">=0.10.4,<1" },
     { name = "typer", specifier = ">=0.20.0,<1" },
-    { name = "uptime", specifier = ">=3.0.1,<4" },
     { name = "urllib3", specifier = ">=2.5.0" },
     { name = "urllib3", specifier = ">=2.6.3,<3" },
     { name = "wsidicom", specifier = ">=0.28.1,<1" },
@@ -7801,12 +7799,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/eb/21/dd871495af3933e58
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e5/4d/2e577f6db7aa0f932d19f799c18f604b2b302c65f733419b900ec07dbade/universal_pathlib-0.2.6-py3-none-any.whl", hash = "sha256:700dec2b58ef34b87998513de6d2ae153b22f083197dfafb8544744edabd1b18", size = 50087, upload-time = "2024-12-13T00:58:24.582Z" },
 ]
-
-[[package]]
-name = "uptime"
-version = "3.0.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ad/53/6c420ddf6949097d6f9406358951c9322505849bea9cb79efe3acc0bb55d/uptime-3.0.1.tar.gz", hash = "sha256:7c300254775b807ce46e3dcbcda30aa3b9a204b9c57a7ac1e79ee6dbe3942973", size = 6630, upload-time = "2013-10-07T14:19:58.456Z" }
 
 [[package]]
 name = "uri-template"


### PR DESCRIPTION
**Why?**
`uptime==3.0.1` is a source-only C extension with no pre-built wheels. On Windows, uv's build isolation uses Python 3.14's `typing.py` when compiling it for older Python versions (3.11–3.13), causing a `SyntaxError` that breaks CI.

**How?**
Remove `uptime` from dependencies and replace its two call sites in `system/_service.py` with `psutil` equivalents: boot time via `psutil.boot_time()` (already a direct dependency with binary wheels for all platforms) and uptime seconds via `time.time() - boot_ts`. The returned dict shape is unchanged.