### PR TITLE
docs(specs): document for_organization from PR #510

### DIFF
--- a/specifications/SPEC-APPLICATION-SERVICE.md
+++ b/specifications/SPEC-APPLICATION-SERVICE.md
@@ -285,6 +285,39 @@ class Service:
             RuntimeError: When download operation fails
         """
         pass
+
+    def application_runs(
+        self,
+        application_id: str | None = None,
+        application_version: str | None = None,
+        external_id: str | None = None,
+        has_output: bool = False,
+        note_regex: str | None = None,
+        note_query_case_insensitive: bool = True,
+        tags: set[str] | None = None,
+        query: str | None = None,
+        limit: int | None = None,
+        for_organization: str | None = None,
+    ) -> list[RunData]:
+        """List application runs, optionally scoped to an organization.
+
+        Args:
+            application_id: Filter by application ID.
+            application_version: Filter by application version.
+            external_id: Filter by external ID.
+            has_output: If True, only runs with partial or full output are retrieved.
+            note_regex: Optional regex to filter runs by note metadata.
+            note_query_case_insensitive: If True, note regex matching is case-insensitive.
+            tags: Optional set of tags to filter runs.
+            query: Optional free-text query.
+            limit: Optional maximum number of results to return.
+            for_organization: Return all runs by users of the specified organization
+                              (org admins only). None = current user's runs only.
+
+        Raises:
+            ForbiddenException: When the caller is not an admin of the requested org.
+        """
+        pass
 ```
 
 ### 4.2 CLI Interface
@@ -304,7 +337,7 @@ uvx aignostics application [subcommand] [options]
 - `run prepare`: Generate metadata from source directory
 - `run upload`: Upload files to cloud storage
 - `run submit`: Submit application run
-- `run list`: List application runs
+- `run list [--for-organization ORG_ID]`: List application runs; supports listing all runs for an organization with `--for-organization` (only available to org admins)
 - `run describe`: Get detailed run information
 - `run cancel`: Cancel running application
 - `run result download`: Download run results
@@ -379,13 +412,14 @@ Configuration is managed through environment variables with the prefix `AIGNOSTI
 
 ### 7.1 Error Categories
 
-| Error Type          | Cause                            | Handling Strategy              | User Impact                     |
-| ------------------- | -------------------------------- | ------------------------------ | ------------------------------- |
-| `ValueError`        | Invalid input data or metadata   | Input validation with feedback | Clear validation error messages |
-| `RuntimeError`      | Platform API or operation errors | Retry with exponential backoff | Error details and guidance      |
-| `NotFoundException` | Missing runs or applications     | Graceful rejection with info   | Clear resource not found info   |
-| `FileNotFoundError` | Missing input files              | File validation before upload  | File path verification help     |
-| `ApiException`      | Platform API failures            | Retry mechanism with recovery  | API error details and guidance  |
+| Error Type            | Cause                            | Handling Strategy                                   | User Impact                                |
+| --------------------- | -------------------------------- | --------------------------------------------------- | ------------------------------------------ |
+| `ValueError`          | Invalid input data or metadata   | Input validation with feedback                      | Clear validation error messages            |
+| `RuntimeError`        | Platform API or operation errors | Retry with exponential backoff                      | Error details and guidance                 |
+| `NotFoundException`   | Missing runs or applications     | Graceful rejection with info                        | Clear resource not found info              |
+| `FileNotFoundError`   | Missing input files              | File validation before upload                       | File path verification help                |
+| `ApiException`        | Platform API failures            | Retry mechanism with recovery                       | API error details and guidance             |
+| `ForbiddenException`  | Caller not authorized for the requested org | Caught in CLI; exit 2 with access-denied message | User informed they lack permission    |
 
 ### 7.2 Input Validation
 

--- a/specifications/SPEC_PLATFORM_SERVICE.md
+++ b/specifications/SPEC_PLATFORM_SERVICE.md
@@ -74,14 +74,14 @@ platform/
 ### 2.2 Key Components
 
 | Component        | Type   | Purpose                                                 | Public API                                                                    |
-| ---------------- | ------ | ------------------------------------------------------- | ----------------------------------------------------------------------------- |
+| ---------------- | ------ | ------------------------------------------------------- |-------------------------------------------------------------------------------|
 | `Client`         | Class  | Main entry point for authenticated API operations       | `__init__()`, `me()`, `application()`, `run()`<br/>Static: `get_api_client()` |
 | `Service`        | Class  | Core service with health monitoring and user operations | `login()`, `logout()`, `get_user_info()`, `health()`, `info()`                |
 | `Settings`       | Class  | Environment-aware configuration management              | Property accessors for all auth endpoints                                     |
 | `Applications`   | Class  | Application resource management                         | `list()`, `versions` accessor                                                 |
 | `ApplicationRun` | Class  | Run lifecycle and result management                     | `details()`, `cancel()`, `results()`, `download_to_folder()`                  |
 | `Versions`       | Class  | Application version management                          | `list()`, `list_sorted()`, `latest()`, `details()`                            |
-| `Runs`           | Class  | Application run management and creation                 | `create()`, `list()`, `list_data()`, `__call__()`                             |
+| `Runs`           | Class  | Application run management and creation                 | `create()`, `list()` / `list_data()`, `__call__()`                            |
 | `utils`          | Module | Resource utility functions and pagination helpers       | `paginate()`                                                                  |
 
 ### 2.3 Design Patterns
@@ -286,11 +286,55 @@ class Runs:
     def create(self, application_version: str, items: list[ItemCreationRequest]) -> ApplicationRun:
         """Creates a new application run."""
 
-    def list(self, for_application_version: str | None = None) -> Generator[ApplicationRun, Any, None]:
-        """Find application runs, optionally filtered by application version."""
+    def list(
+        self,
+        application_id: str | None = None,
+        application_version: str | None = None,
+        external_id: str | None = None,
+        custom_metadata: str | None = None,
+        sort: str | None = None,
+        page_size: int = 100,
+        nocache: bool = False,
+        for_organization: str | None = None,
+    ) -> Iterator[ApplicationRun]:
+        """Find application runs, optionally filtered by application version.
 
-    def list_data(self, for_application_version: str | None = None, sort: str | None = None, page_size: int = 100) -> Iterator[ApplicationRunData]:
-        """Fetch application runs data with optional filtering and sorting."""
+        Args:
+            application_id: Filter by application ID.
+            application_version: Filter by application version.
+            external_id: Filter by external ID.
+            custom_metadata: Optional metadata filter in JSONPath format.
+            sort: Optional field to sort by. Prefix with '-' for descending order.
+            page_size: Number of results per page (default 100).
+            nocache: If True, bypass cache and force a fresh API call.
+            for_organization: Return all runs by users of the specified organization (org admins only).
+                              None = current user's runs only.
+        """
+
+    def list_data(
+        self,
+        application_id: str | None = None,
+        application_version: str | None = None,
+        external_id: str | None = None,
+        custom_metadata: str | None = None,
+        sort: str | None = None,
+        page_size: int = 100,
+        nocache: bool = False,
+        for_organization: str | None = None,
+    ) -> Iterator[ApplicationRunData]:
+        """Fetch application runs data with optional filtering and sorting.
+
+        Args:
+            application_id: Filter by application ID.
+            application_version: Filter by application version.
+            external_id: Filter by external ID.
+            custom_metadata: Optional metadata filter in JSONPath format.
+            sort: Optional field to sort by. Prefix with '-' for descending order.
+            page_size: Number of results per page (default 100).
+            nocache: If True, bypass cache and force a fresh API call.
+            for_organization: Return all runs by users of the specified organization (org admins only).
+                              None = current user's runs only.
+        """
 
     def __call__(self, application_run_id: str) -> ApplicationRun:
         """Retrieves an ApplicationRun instance for an existing run."""
@@ -447,13 +491,14 @@ The Platform module provides foundational services but does not directly expose 
 
 ### 7.1 Error Categories
 
-| Error Type            | Cause                                    | Handling Strategy                                   | User Impact                                  |
-| --------------------- | ---------------------------------------- | --------------------------------------------------- | -------------------------------------------- |
-| `AuthenticationError` | Invalid credentials or network issues    | Retry with exponential backoff; clear cached tokens | User prompted to re-authenticate             |
-| `ConfigurationError`  | Invalid settings or missing endpoints    | Validate on startup; provide clear error messages   | Application fails fast with actionable error |
-| `NetworkError`        | Connection timeouts or proxy issues      | Retry with backoff; fallback to device flow         | Automatic retry or alternative auth flow     |
-| `TokenExpiredError`   | JWT token past expiration                | Automatic refresh using refresh token               | Transparent token renewal                    |
-| `ValidationError`     | Invalid input parameters or file formats | Input sanitization and validation                   | Clear validation error messages              |
+| Error Type             | Cause                                    | Handling Strategy                                   | User Impact                                  |
+| ---------------------- | ---------------------------------------- | --------------------------------------------------- | -------------------------------------------- |
+| `AuthenticationError`  | Invalid credentials or network issues    | Retry with exponential backoff; clear cached tokens | User prompted to re-authenticate             |
+| `ConfigurationError`   | Invalid settings or missing endpoints    | Validate on startup; provide clear error messages   | Application fails fast with actionable error |
+| `NetworkError`         | Connection timeouts or proxy issues      | Retry with backoff; fallback to device flow         | Automatic retry or alternative auth flow     |
+| `TokenExpiredError`    | JWT token past expiration                | Automatic refresh using refresh token               | Transparent token renewal                    |
+| `ValidationError`      | Invalid input parameters or file formats | Input sanitization and validation                   | Clear validation error messages              |
+| `ForbiddenException`   | Caller not authorized for the requested org | Caught in CLI; exit 2 with access-denied message | User informed they lack permission           |
 
 ### 7.2 Input Validation
 


### PR DESCRIPTION
**Why?**
PR #510 added `for_organization` support to `Runs.list()` / `Runs.list_data()` and `Service.application_runs()`, a `--for-organization` CLI flag on `run list`, and `ForbiddenException` as a public export, but none of these were reflected in the specification files.

**How?**
Updated `SPEC_PLATFORM_SERVICE.md` and `SPEC-APPLICATION-SERVICE.md` to add `for_organization: str | None = None` to the relevant method signatures, document the `--for-organization` CLI flag and its error/empty-result behaviour, and add `ForbiddenException` rows to both error-category tables.