### PR TITLE
fix(ci): prevent PYTHONHOME leak in Windows nox sub-sessions

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -893,6 +893,15 @@ def _run_test_suite(session: nox.Session, marker: str = "", cov_append: bool = F
         marker: Pytest marker expression
         cov_append: Whether to append to existing coverage data
     """
+    # On Windows, uv run sets PYTHONHOME to the managed Python 3.14 install dir when it
+    # starts nox. This leaks into pytest sub-processes for older Python versions (3.11-3.13)
+    # and causes them to load Python 3.14's stdlib, crashing at startup.
+    # Fix: set PYTHONHOME to None in session.env so nox strips it from the subprocess
+    # environment entirely (nox._clean_env filters out None-valued entries before passing
+    # to subprocess.Popen). Unlike os.environ.pop(), this does NOT mutate global process
+    # state; it only affects subprocesses spawned by session.run() / session.run_install().
+    if platform.system() == "Windows":
+        session.env["PYTHONHOME"] = None
     _setup_venv(session)
 
     posargs = session.posargs[:]


### PR DESCRIPTION
**Why?**
Windows CI fails for Python 3.11, 3.12, and 3.13 because `uv run` sets `PYTHONHOME` to the managed Python 3.14 install directory when launching nox. This leaks into pytest sub-processes for older Python versions, causing them to load 3.14's stdlib and crash at startup (SyntaxError on 3.11; fatal `init_import_site` on 3.12/3.13).

**How?**
On Windows only, strip `PYTHONHOME` from the session's subprocess environment in `_run_test_suite` before any pytest process is spawned. The fix is guarded by `platform.system() == "Windows"` to avoid affecting coverage collection on Linux/macOS.