### PR TITLE
fix(ci): replace \d with [0-9] in semver validation grep

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -51,7 +51,7 @@ jobs:
           INPUT: ${{ inputs.version }}
         run: |
           # Must be an explicit x.y.z semver
-          if ! echo "$INPUT" | grep -qE '^\d+\.\d+\.\d+$'; then
+          if ! echo "$INPUT" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
             echo "❌ Invalid version: '$INPUT'. Must be an explicit semver like '1.3.0'."
             exit 1
           fi


### PR DESCRIPTION
**Why?**
The `prepare-release` workflow was rejecting valid semver inputs like `1.3.0` because the grep pattern used `\d` to match digits. `\d` is a PCRE extension and is not recognised by POSIX ERE (`grep -E`), the mode used on the GitHub Actions Ubuntu runner.

**How?**
Replace `\d` with `[0-9]` in the semver validation regex, making it valid POSIX ERE and portable across all GNU/Linux environments.