### PR TITLE
ci: pass release version to Ketryx on release/v* branches

### DIFF
--- a/.github/workflows/_ketryx_report_and_check.yml
+++ b/.github/workflows/_ketryx_report_and_check.yml
@@ -7,9 +7,13 @@ on:
         description: 'Commit message to check for skip markers'
         required: false
         type: string
-
       commit-sha:
-        required: true
+        description: 'Commit SHA to associate the build with (used when version is not set)'
+        required: false
+        type: string
+      version:
+        description: 'Ketryx version ID to associate the build with; takes precedence over commit-sha (use on release/v* branches)'
+        required: false
         type: string
     secrets:
       KETRYX_PROJECT:
@@ -59,7 +63,8 @@ jobs:
         with:
           project: ${{ secrets.KETRYX_PROJECT }}
           api-key: ${{ secrets.KETRYX_API_KEY }}
-          commit-sha: ${{ inputs.commit-sha }}
+          commit-sha: ${{ inputs.version == '' && inputs.commit-sha || '' }}
+          version: ${{ inputs.version }}
           build-name: "ci-cd"
           test-junit-path: test-results/junit_*.xml
           cyclonedx-json-path: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -8,7 +8,9 @@ on:
     tags:
       - "v*.*.*"
   pull_request:
-    branches: [main]
+    branches:
+      - "main"
+      - "release/v*"
     types: [opened, synchronize, reopened]
   release:
     types: [created]

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -35,11 +35,24 @@ jobs:
       contents: read
     outputs:
       commit_message: ${{ steps.get-commit-message.outputs.commit_message }}
+      release_version: ${{ steps.get-release-version.outputs.release_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+
+      - name: Get release version from branch name
+        id: get-release-version
+        shell: bash
+        env:
+          GITHUB_REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "$GITHUB_REF_NAME" =~ ^release/v(.+)$ ]]; then
+            echo "release_version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+          else
+            echo "release_version=" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Get commit message
         id: get-commit-message
@@ -166,6 +179,7 @@ jobs:
     uses: ./.github/workflows/_ketryx_report_and_check.yml
     with:
       commit-sha: ${{ github.event.pull_request.head.sha || github.sha }}
+      version: ${{ needs.get-commit-message.outputs.release_version }}
       commit_message: ${{ needs.get-commit-message.outputs.commit_message }}
     permissions:
       attestations: write


### PR DESCRIPTION
**Why?**
When CI runs on a `release/v*` branch, Ketryx should associate the build with the named release version (e.g. `1.2.3`) rather than a transient commit SHA, so that compliance approvals collected during the prepare-release phase are correctly linked. PRs targeting release branches should also trigger the full CI/CD pipeline.

**How?**
The `get-commit-message` job now extracts the semver from the branch name and exposes it as `release_version`. This is forwarded to `_ketryx_report_and_check.yml` as a new optional `version` input; when set, it is passed to the Ketryx action and `commit-sha` is omitted. On all other contexts (PRs to main, main pushes, tags) the existing commit-SHA behaviour is unchanged. The `pull_request` trigger is also extended to include `release/v*` base branches.