### PR TITLE
fix(docs): correct skip:test:long_running label name in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,7 +32,7 @@ If you write code yourself, it is a strict requirement to validate your work on 
 
 If you you are creating a pull request yourself:
 
-* Add a label skip:test_long_running, to skip running long running tests. This is important because some tests in this repository are marked as long_running and can take a significant amount of time to complete. By adding this label, you help ensure that the CI pipeline runs efficiently and avoids unnecessary delays.
+* Add a label skip:test:long_running, to skip running long running tests. This is important because some tests in this repository are marked as long_running and can take a significant amount of time to complete. By adding this label, you help ensure that the CI pipeline runs efficiently and avoids unnecessary delays.
 
 ## Module Documentation Index
 
@@ -1163,7 +1163,7 @@ git push origin feat/my-feature
 gh pr create --title "feat: add operation caching" --body "Description..."
 
 # IMPORTANT: Add label to skip long-running tests
-gh pr edit --add-label "skip:test_long_running"
+gh pr edit --add-label "skip:test:long_running"
 ```
 
 **PR triggers:**
@@ -1367,7 +1367,7 @@ git commit -m "docs: update README [skip ci]"
 git commit -m "skip:ci: work in progress"
 
 # Add PR label to skip long-running tests
-gh pr edit --add-label "skip:test_long_running"
+gh pr edit --add-label "skip:test:long_running"
 ```
 
 ### IDE Setup Recommendations


### PR DESCRIPTION
🛡️ Resolves [PYSDK-89](https://aignx.atlassian.net/browse/PYSDK-89) following [PR-SOP-01 Problem Resolution and Non-Conforming Products](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM/pages/1225392129/PR-SOP-01+Problem+Resolution+and+Non-Conforming+Products), part of our [ISO 13485-certified QMS](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM) | [Ketryx Project](https://app.ketryx.com/projects/KXPRJ2Q4PA8AADY975SFMKF276TYV75)

## Summary

- Fix 3 occurrences of `skip:test_long_running` (underscores) → `skip:test:long_running` (colons) in `CLAUDE.md`
- The wrong separator caused `gh pr edit --add-label` to fail with "label not found" when Claude Code created PRs
- `.github/CLAUDE.md` already used the correct colon form throughout

## Root cause

Implementation error: the label name in `CLAUDE.md` was written with underscores when the PR label naming convention was established. `.github/CLAUDE.md` had the correct form but `CLAUDE.md` was not kept in sync.

## Test plan

- [ ] Verify `gh pr edit --add-label "skip:test:long_running"` succeeds on a test PR
- [ ] Verify `CLAUDE.md` no longer contains `skip:test_long_running`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[PYSDK-89]: https://aignx.atlassian.net/browse/PYSDK-89?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ