### PR TITLE
fix(ci): include v prefix in release_version output for Ketryx

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -51,7 +51,8 @@ jobs:
           GITHUB_REF_NAME: ${{ github.ref_name }}
         run: |
           if [[ "$GITHUB_REF_NAME" =~ ^release/v(.+)$ ]]; then
-            echo "release_version=${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
+            # Ketryx version names start with "v", so we must preserve the prefix.
+            echo "release_version=v${BASH_REMATCH[1]}" >> "$GITHUB_OUTPUT"
           else
             echo "release_version=" >> "$GITHUB_OUTPUT"
           fi


### PR DESCRIPTION
**Why?**
The `get-release-version` CI step was outputting a bare semver (e.g. `1.3.0`) when extracting the version from a `release/vX.Y.Z` branch name. Ketryx expects version names prefixed with `v` (e.g. `v1.3.0`), so the compliance check was receiving a version string in the wrong format.

**How?**
Prepend `v` to the captured regex group when writing to `$GITHUB_OUTPUT`, and add a comment explaining the requirement. The regex already strips the `v` by capturing only the part after it, so the fix is a minimal one-character change at the output line.