### PR TITLE
ci: auto-enable very_long_running tests on release branch pushes

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -259,8 +259,8 @@ uv run pytest -m long_running -v
 
 **CI Behavior**:
 
-* **NEVER run by default**
-* **Only run when explicitly enabled** via:
+* **Automatically run on every push to `release/v*` branches** (no opt-in needed)
+* **Otherwise never run by default** — must be explicitly enabled via:
   * PR label `enable:test:very_long_running`, OR
   * Commit message contains `enable:test:very_long_running`
 

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -217,7 +217,8 @@ jobs:
         if: |
           !cancelled() && (
             contains(inputs.commit_message, 'enable:test:very_long_running') ||
-            contains(github.event.pull_request.labels.*.name, 'enable:test:very_long_running')
+            contains(github.event.pull_request.labels.*.name, 'enable:test:very_long_running') ||
+            (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/v'))
           )
         uses: ./.github/actions/run-tests
         with:


### PR DESCRIPTION
**Why?**
Release branches must be fully validated before publishing. The `very_long_running` test suite was never included automatically, meaning some test cases weren't part of the build reported to Ketryx.

**How?**
Added a third OR-condition to the `e2e_very_long_running` step's `if:` expression in `_test.yml`: `(github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/v'))`. In a reusable workflow, these context variables reflect the caller's trigger, so this fires on direct pushes to release branches but not on PRs targeting them (where `event_name` is `pull_request`). Updated `.github/CLAUDE.md` to document the new behaviour.