### PR TITLE
chore: remove broken Codecov VS Code extension from recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,8 +2,7 @@
     "recommendations": [
         "bierner.markdown-mermaid",
         "charliermarsh.ruff",
-        "codecov.codecov",
-        "daelonsuzuka.nicegui",
+"daelonsuzuka.nicegui",
         "donjayamanne.python-environment-manager",
         "fill-labs.dependi",
         "github.vscode-github-actions",


### PR DESCRIPTION
🛡️ Implements [PYSDK-90](https://aignx.atlassian.net/browse/PYSDK-90) following [CC-SOP-01 Change Control](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM/pages/86802705/CC-SOP-01+Change+Control), part of our [ISO 13485-certified QMS](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM) | [Ketryx Project](https://app.ketryx.com/projects/KXPRJ2Q4PA8AADY975SFMKF276TYV75)

## Summary

- Removes `codecov.codecov` from the recommended VS Code extensions list
- The Codecov extension is broken and no longer maintained
- Prevents VS Code from prompting developers to install a non-functional extension

## Test plan

- [ ] Verify `.vscode/extensions.json` no longer lists `codecov.codecov`
- [ ] Open repo in VS Code and confirm no Codecov extension install prompt appears

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[PYSDK-90]: https://aignx.atlassian.net/browse/PYSDK-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ