### PR TITLE
chore: update compass.yml — Jira board, status page, tier, lifecycle and metadata [PYSDK-82]

### DIFF
--- a/compass.yml
+++ b/compass.yml
@@ -10,6 +10,9 @@ links:
   - name: null
     type: REPOSITORY
     url: https://github.com/aignostics/python-sdk
+  - name: Jira Board
+    type: PROJECT_TRACKER
+    url: https://aignx.atlassian.net/jira/software/projects/PYSDK/boards
 relationships:
   DEPENDS_ON: []
 labels:

--- a/compass.yml
+++ b/compass.yml
@@ -1,11 +1,15 @@
 name: python-sdk
 id: ari:cloud:compass:fff788d2-8a2a-4c36-a884-dde2bb4a2b49:component/f65912bc-77bd-4e1f-b333-1a9e8f0ac32c/aca547e5-2577-4f9d-9aaa-cf360acc976c
-description: 🔬 Python SDK providing access to the Aignostics Platform. Includes Aignostics Launchpad (Desktop Application), Aignostics CLI (Command-Line Interface), example notebooks, and Aignostics Client Library.
+description: 🔬 Python SDK providing access to the Aignostics Platform. Includes
+  Aignostics Launchpad (Desktop Application), Aignostics CLI (Command-Line
+  Interface), example notebooks, and Aignostics Client Library.
 configVersion: 1
 typeId: APPLICATION
 ownerId: ari:cloud:identity::team/b1cfb598-3138-4c2a-8b6a-19fb1078645b
 fields:
-  tier: 4
+  tier: 1
+  lifecycle: Active
+  isMonorepoProject: false
 links:
   - name: null
     type: REPOSITORY
@@ -44,25 +48,25 @@ customFields:
     value: false
   - name: Component Key
     type: text
-    value: null
+    value: python-sdk
   - name: Deployment Branch
     type: text
-    value: null
+    value: release/*
   - name: Development Branch
     type: text
-    value: null
+    value: main
   - name: FinOps Label
     type: text
     value: null
   - name: Has external API
     type: boolean
-    value: false
+    value: true
   - name: Has external CLI
     type: boolean
-    value: false
+    value: true
   - name: Has external graphical UI
     type: boolean
-    value: false
+    value: true
   - name: Has internal API
     type: boolean
     value: false
@@ -74,10 +78,12 @@ customFields:
     value: false
   - name: Is independently deployable
     type: boolean
-    value: false
+    value: true
+  - name: Is open source
+    type: true
   - name: Path in Repository
     type: text
-    value: null
+    value: /
   - name: Process Level
     type: single_select
     value: null

--- a/compass.yml
+++ b/compass.yml
@@ -13,6 +13,9 @@ links:
   - name: Jira Board
     type: PROJECT_TRACKER
     url: https://aignx.atlassian.net/jira/software/projects/PYSDK/boards
+  - name: Status Page
+    type: STATUS_PAGE
+    url: https://status.aignostics.com
 relationships:
   DEPENDS_ON: []
 labels:


### PR DESCRIPTION
🛡️ Implements [PYSDK-82](https://aignx.atlassian.net/browse/PYSDK-82) following [CC-SOP-01 Change Control](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM/pages/86802705/CC-SOP-01+Change+Control), part of our [ISO 13485-certified QMS](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM) | [Ketryx Project](https://app.ketryx.com/projects/KXPRJ2Q4PA8AADY975SFMKF276TYV75)

## Summary

- Add Jira board link (`PROJECT_TRACKER`) pointing to the PYSDK board in Compass
- Add BetterStack status page link (`STATUS_PAGE`) pointing to status.aignostics.com
- Set tier to 1, lifecycle to Active, isMonorepoProject to false
- Populate previously empty custom fields: Component Key, Deployment Branch, Development Branch, Has external API/CLI/GUI, Is independently deployable, Is open source, Path in Repository

## Why

Enriches the Compass component catalog entry so the Python SDK is correctly classified, linked to its operational resources, and visible to on-call and platform teams.

## Test plan

- [ ] Verify Compass component page shows Jira board and status page links after merge
- [ ] Verify tier and lifecycle fields are reflected in Compass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[PYSDK-82]: https://aignx.atlassian.net/browse/PYSDK-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ