### PR TITLE
fix: correct invalid compass.yml link types and custom field type [PYSDK-83]

### DIFF
--- a/compass.yml
+++ b/compass.yml
@@ -15,10 +15,10 @@ links:
     type: REPOSITORY
     url: https://github.com/aignostics/python-sdk
   - name: Jira Board
-    type: PROJECT_TRACKER
+    type: PROJECT
     url: https://aignx.atlassian.net/jira/software/projects/PYSDK/boards
   - name: Status Page
-    type: STATUS_PAGE
+    type: OTHER_LINK
     url: https://status.aignostics.com
 relationships:
   DEPENDS_ON: []
@@ -80,7 +80,8 @@ customFields:
     type: boolean
     value: true
   - name: Is open source
-    type: true
+    type: boolean
+    value: true
   - name: Path in Repository
     type: text
     value: /


### PR DESCRIPTION
🛡️ Resolves [PYSDK-83](https://aignx.atlassian.net/browse/PYSDK-83) following [PR-SOP-01 Problem Resolution and Non-Conforming Products](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM/pages/1225392129/PR-SOP-01+Problem+Resolution+and+Non-Conforming+Products), part of our [ISO 13485-certified QMS](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM) | [Ketryx Project](https://app.ketryx.com/projects/KXPRJ2Q4PA8AADY975SFMKF276TYV75)

## Summary

- `PROJECT_TRACKER` → `PROJECT` (invalid link type)
- `STATUS_PAGE` → `OTHER_LINK` (invalid link type)
- `Is open source` custom field `type: true` → `type: boolean` with `value: true` (invalid customField type)

## Root Cause

Implementation error in PYSDK-82: used undocumented/invalid enum values for Compass link types and custom field types, causing the Compass sync to fail immediately after merge.

## Test Plan

- [ ] Compass sync succeeds after merge (check Compass component page for python-sdk)

[PYSDK-83]: https://aignx.atlassian.net/browse/PYSDK-83?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ