### PR TITLE
chore: add service dependencies and process level to compass.yml [PYSDK-84]

### DIFF
--- a/compass.yml
+++ b/compass.yml
@@ -23,6 +23,8 @@ links:
 relationships:
   DEPENDS_ON:
     - 'ari:cloud:compass:fff788d2-8a2a-4c36-a884-dde2bb4a2b49:component/f65912bc-77bd-4e1f-b333-1a9e8f0ac32c/638f89c6-24a3-48f4-90ad-1b09ef8d32c6'
+    - 'ari:cloud:compass:fff788d2-8a2a-4c36-a884-dde2bb4a2b49:component/f65912bc-77bd-4e1f-b333-1a9e8f0ac32c/8a5a2394-89b7-4c84-9b14-947ce2cf9fdd'
+    - 'ari:cloud:compass:fff788d2-8a2a-4c36-a884-dde2bb4a2b49:component/f65912bc-77bd-4e1f-b333-1a9e8f0ac32c/b2f7a1a1-112c-4d68-aa3c-7ce0c04eda2d'
 labels:
   - aignostics
   - atlas
@@ -88,4 +90,4 @@ customFields:
     value: /
   - name: Process Level
     type: single_select
-    value: null
+    value: CLIENT_FACING

--- a/compass.yml
+++ b/compass.yml
@@ -23,6 +23,9 @@ links:
   - name: '#python-sdk-dev'
     type: CHAT_CHANNEL
     url: https://slack.com/app_redirect?channel=C098D8MH431
+  - name: Sentry
+    type: OTHER_LINK
+    url: https://aignostics.sentry.io/projects/python-sdk/
 relationships:
   DEPENDS_ON:
     - 'ari:cloud:compass:fff788d2-8a2a-4c36-a884-dde2bb4a2b49:component/f65912bc-77bd-4e1f-b333-1a9e8f0ac32c/638f89c6-24a3-48f4-90ad-1b09ef8d32c6'

--- a/compass.yml
+++ b/compass.yml
@@ -21,7 +21,8 @@ links:
     type: OTHER_LINK
     url: https://status.aignostics.com
 relationships:
-  DEPENDS_ON: []
+  DEPENDS_ON:
+    - 'ari:cloud:compass:fff788d2-8a2a-4c36-a884-dde2bb4a2b49:component/f65912bc-77bd-4e1f-b333-1a9e8f0ac32c/638f89c6-24a3-48f4-90ad-1b09ef8d32c6'
 labels:
   - aignostics
   - atlas

--- a/compass.yml
+++ b/compass.yml
@@ -20,6 +20,9 @@ links:
   - name: Status Page
     type: OTHER_LINK
     url: https://status.aignostics.com
+  - name: '#python-sdk-dev'
+    type: CHAT_CHANNEL
+    url: https://slack.com/app_redirect?channel=C098D8MH431
 relationships:
   DEPENDS_ON:
     - 'ari:cloud:compass:fff788d2-8a2a-4c36-a884-dde2bb4a2b49:component/f65912bc-77bd-4e1f-b333-1a9e8f0ac32c/638f89c6-24a3-48f4-90ad-1b09ef8d32c6'


### PR DESCRIPTION
🛡️ Implements [PYSDK-84](https://aignx.atlassian.net/browse/PYSDK-84) following [CC-SOP-01 Change Control](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM/pages/86802705/CC-SOP-01+Change+Control), part of our [ISO 13485-certified QMS](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM) | [Ketryx Project](https://app.ketryx.com/projects/KXPRJ2Q4PA8AADY975SFMKF276TYV75)

## Summary

- Adds three runtime service dependencies to `relationships.DEPENDS_ON`:
  - **Samia Service** — Aignostics Platform API backend
  - **Aignostics Console** — AKA PAPI Management UI
  - **platform-console**
- Sets `Process Level` custom field to `CLIENT_FACING` (highest classification — customer-facing regulated product)
- Adds `#python-sdk-dev` Slack channel as a `CHAT_CHANNEL` link
- Adds Sentry project as an `OTHER_LINK` for error monitoring

## Why

These changes make the SDK's actual runtime service graph, team communication channel, and error monitoring project explicit in the Compass catalog, enabling accurate impact analysis and discoverability.

## Test plan

- [ ] Compass component page for `python-sdk` shows all three services under Dependencies after merge and re-sync
- [ ] Process Level shows `CLIENT_FACING` in the component UI
- [ ] `#python-sdk-dev` appears under Chat Channels in the component UI
- [ ] Sentry link appears under Links in the component UI
- [ ] No Compass sync errors (check component page banner)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[PYSDK-84]: https://aignx.atlassian.net/browse/PYSDK-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ