### PR TITLE
fix: use UUID for Process Level single_select in compass.yml [PYSDK-85]

### DIFF
--- a/compass.yml
+++ b/compass.yml
@@ -96,4 +96,4 @@ customFields:
     value: /
   - name: Process Level
     type: single_select
-    value: CLIENT_FACING
+    value: 7a2a380d-da85-476f-ae5d-dfc034889b61


### PR DESCRIPTION
🛡️ Resolves [PYSDK-85](https://aignx.atlassian.net/browse/PYSDK-85) following [PR-SOP-01 Problem Resolution and Non-Conforming Products](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM/pages/1225392129/PR-SOP-01+Problem+Resolution+and+Non-Conforming+Products), part of our [ISO 13485-certified QMS](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM) | [Ketryx Project](https://app.ketryx.com/projects/KXPRJ2Q4PA8AADY975SFMKF276TYV75)

## Summary

- Fixes Compass sync failure: `option id: "CLIENT_FACING" must be of type "UUID"`
- Changes `Process Level` custom field value from human-readable string `CLIENT_FACING` to its UUID `7a2a380d-da85-476f-ae5d-dfc034889b61`
- Compass config-as-code requires `single_select` field values to be option UUIDs, not display names

## Root cause

The `customFields[name="Process Level"]` entry used the human-readable enum string `CLIENT_FACING` instead of the option UUID required by Compass. The UUID was retrieved via `getCompassCustomFieldDefinitions`.

## Test plan

- [ ] Push branch and verify Compass sync succeeds (no "Last compass.yml sync failed" banner on the component page)
- [ ] CI green on this branch

[PYSDK-85]: https://aignx.atlassian.net/browse/PYSDK-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ