### PR TITLE
fix: use correct board URL for classic Jira project in compass.yml [PYSDK-86]

### DIFF
--- a/compass.yml
+++ b/compass.yml
@@ -16,7 +16,7 @@ links:
     url: https://github.com/aignostics/python-sdk
   - name: Jira Board
     type: PROJECT
-    url: https://aignx.atlassian.net/jira/software/projects/PYSDK/boards
+    url: https://aignx.atlassian.net/jira/software/c/projects/PYSDK/boards
   - name: Status Page
     type: OTHER_LINK
     url: https://status.aignostics.com


### PR DESCRIPTION
🛡️ Resolves [PYSDK-86](https://aignx.atlassian.net/browse/PYSDK-86) following [PR-SOP-01 Problem Resolution and Non-Conforming Products](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM/pages/1225392129/PR-SOP-01+Problem+Resolution+and+Non-Conforming+Products), part of our [ISO 13485-certified QMS](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM) | [Ketryx Project](https://app.ketryx.com/projects/KXPRJ2Q4PA8AADY975SFMKF276TYV75)

## Summary

- Fixes the Jira Board link in `compass.yml`: `/jira/software/projects/PYSDK/boards` → `/jira/software/c/projects/PYSDK/boards`
- The PYSDK project is a **classic** (company-managed) Jira project; classic projects require `/c/` in their board URL — the next-gen format returns a 404

## Root cause

Jira Cloud has two project styles: next-gen (team-managed) and classic (company-managed). Classic projects use `/c/` in the board URL. The URL was set using the next-gen format, likely copied from documentation targeting next-gen projects.

## Test plan

- [ ] Open `https://aignx.atlassian.net/jira/software/c/projects/PYSDK/boards` — verify it loads the board
- [ ] CI green on this branch
- [ ] Check Compass component UI after merge — verify no sync failure banner

[PYSDK-86]: https://aignx.atlassian.net/browse/PYSDK-86?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ