### PR TITLE
chore: add #python-sdk-notifications Slack channel to compass.yml [PYSDK-87]

### DIFF
--- a/compass.yml
+++ b/compass.yml
@@ -23,6 +23,9 @@ links:
   - name: '#python-sdk-dev'
     type: CHAT_CHANNEL
     url: https://slack.com/app_redirect?channel=C098D8MH431
+  - name: '#python-sdk-notifications'
+    type: CHAT_CHANNEL
+    url: https://slack.com/app_redirect?channel=C0AUPTA5QF9
   - name: Sentry
     type: OTHER_LINK
     url: https://aignostics.sentry.io/projects/python-sdk/


### PR DESCRIPTION
🛡️ Implements [PYSDK-87](https://aignx.atlassian.net/browse/PYSDK-87) following [CC-SOP-01 Change Control](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM/pages/86802705/CC-SOP-01+Change+Control), part of our [ISO 13485-certified QMS](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM) | [Ketryx Project](https://app.ketryx.com/projects/KXPRJ2Q4PA8AADY975SFMKF276TYV75)

## Summary

- Adds `#python-sdk-notifications` (`C0AUPTA5QF9`) as a second `CHAT_CHANNEL` link in `compass.yml`
- This channel is used for Jira state transition notifications via the Jira Cloud for Slack integration
- `#python-sdk-dev` remains as the developer discussion channel

## Why

Having a dedicated notifications channel keeps automated Jira signals (state transitions, PR status) separate from developer discussion in `#python-sdk-dev`, making both channels easier to follow.

## Test plan

- [ ] Merge PR
- [ ] In `#python-sdk-notifications`, type `/jira connect` and connect the PYSDK project
- [ ] Type `/jira manage` to configure: enable "Issue transitioned" notifications
- [ ] Transition a test Jira issue and verify the notification appears in the channel

[PYSDK-87]: https://aignx.atlassian.net/browse/PYSDK-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ