### PR TITLE
chore: fix link types and add missing Ketryx link in compass.yml [PYSDK-88]

### DIFF
--- a/compass.yml
+++ b/compass.yml
@@ -18,7 +18,7 @@ links:
     type: PROJECT
     url: https://aignx.atlassian.net/jira/software/c/projects/PYSDK/boards
   - name: Status Page
-    type: OTHER_LINK
+    type: DASHBOARD
     url: https://status.aignostics.com
   - name: '#python-sdk-dev'
     type: CHAT_CHANNEL
@@ -26,8 +26,11 @@ links:
   - name: '#python-sdk-notifications'
     type: CHAT_CHANNEL
     url: https://slack.com/app_redirect?channel=C0AUPTA5QF9
-  - name: Sentry
+  - name: Ketryx Project
     type: OTHER_LINK
+    url: https://app.ketryx.com/projects/KXPRJ2Q4PA8AADY975SFMKF276TYV75
+  - name: Sentry
+    type: DASHBOARD
     url: https://aignostics.sentry.io/projects/python-sdk/
 relationships:
   DEPENDS_ON:

--- a/compass.yml
+++ b/compass.yml
@@ -16,7 +16,7 @@ links:
     url: https://github.com/aignostics/python-sdk
   - name: Jira Board
     type: PROJECT
-    url: https://aignx.atlassian.net/jira/software/c/projects/PYSDK/boards
+    url: https://aignx.atlassian.net/jira/software/c/projects/PYSDK/boards/1799
   - name: Status Page
     type: DASHBOARD
     url: https://status.aignostics.com


### PR DESCRIPTION
🛡️ Implements [PYSDK-88](https://aignx.atlassian.net/browse/PYSDK-88) following [CC-SOP-01 Change Control](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM/pages/86802705/CC-SOP-01+Change+Control), part of our [ISO 13485-certified QMS](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM) | [Ketryx Project](https://app.ketryx.com/projects/KXPRJ2Q4PA8AADY975SFMKF276TYV75)

## Summary

- `Status Page`: `OTHER_LINK` → `DASHBOARD` (uptime/reliability KPIs)
- `Sentry`: `OTHER_LINK` → `DASHBOARD` (observability — fits Compass "KPIs, observability, or usage")
- Add missing `Ketryx Project` `OTHER_LINK` — required by SW-SOP-01 but absent from main
- Fix Jira board URL: `/boards` → `/boards/1799` (classic projects require the numeric board ID; the generic `/boards` path returns 404)

## Why

The Compass UI describes Dashboards as "Add dashboards for KPIs, observability, or usage". Both the BetterStack Status Page (uptime/reliability metrics) and Sentry (error observability) fit this better than Other Links.

The Ketryx link was dropped when PYSDK-85's fix branch did not carry it forward after merge.

The Jira board URL `/jira/software/c/projects/PYSDK/boards` returns 404 — the working URL is `/jira/software/c/projects/PYSDK/boards/1799`.

## Test plan

- [ ] CI green
- [ ] After merge: Compass shows Status Page and Sentry under Dashboards
- [ ] Ketryx Project link appears under Other Links
- [ ] Jira Board link opens correctly at `/boards/1799`
- [ ] No "compass.yml sync failed" banner

[PYSDK-88]: https://aignx.atlassian.net/browse/PYSDK-88?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ