### PR TITLE
chore(dev): update scalene profile target for v2 API [PYSDK-91]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,8 @@ CLAUDE.local.md
 # Scalene
 profile.json
 profile.html
+scalene-profile.json
+scalene-profile.html
 
 # Nicegui
 .nicegui

--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,7 @@ gui_watch:
 	uv run runner/gui_watch.py
 
 profile:
-	uv run --all-extras python -m scalene runner/scalene.py
+	uv run --all-extras python -m scalene run runner/scalene.py --outfile tmp/scalene-profile.json && uv run --all-extras python -m scalene view tmp/scalene-profile.json
 
 # Signing: https://gist.github.com/bpteague/750906b9a02094e7389427d308ba1002
 dist_native:

--- a/Makefile
+++ b/Makefile
@@ -162,6 +162,7 @@ gui_watch:
 	uv run runner/gui_watch.py
 
 profile:
+	mkdir -p tmp
 	uv run --all-extras python -m scalene run runner/scalene.py --outfile tmp/scalene-profile.json && uv run --all-extras python -m scalene view tmp/scalene-profile.json
 
 # Signing: https://gist.github.com/bpteague/750906b9a02094e7389427d308ba1002


### PR DESCRIPTION
🛡️ Implements [PYSDK-91](https://aignx.atlassian.net/browse/PYSDK-91) following [CC-SOP-01 Change Control](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM/pages/86802705/CC-SOP-01+Change+Control), part of our [ISO 13485-certified QMS](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM) | [Ketryx Project](https://app.ketryx.com/projects/KXPRJ2Q4PA8AADY975SFMKF276TYV75)

## Summary

- Update `make profile` to use scalene v2's explicit `run` and `view` subcommands (previously a single invocation worked in v1)
- Write profile output to `tmp/scalene-profile.json` instead of the repo root
- Add `scalene-profile.json` and `scalene-profile.html` to `.gitignore`

## Test plan

- [ ] Run `make profile` and verify it produces output in `tmp/` and opens the viewer

Supersedes #563 (closed due to branch rename for Jira Development panel linkage).

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[PYSDK-91]: https://aignx.atlassian.net/browse/PYSDK-91?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ