### PR TITLE
chore(ci): add sop:*, type:*, security:*, scope:*, auto-merge labels [PYSDK-94]

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -133,3 +133,76 @@
 - name: documentation-drift
   description: Documentation out of sync with code
   color: "ff6b6b"
+
+# SOP Labels — governance trail on every PR (one mandatory)
+- name: sop:pr-sop-01
+  description: PR-SOP-01 Problem Resolution (bug / anomaly fix)
+  color: "5319e7"
+
+- name: sop:cc-sop-01
+  description: CC-SOP-01 Change Control (feature / planned change)
+  color: "1d76db"
+
+# Type Labels — conventional-commits taxonomy (one per PR)
+# Extends the legacy `bug` / `documentation` / `enhancement` labels with
+# the rest of the conventional-commit vocabulary. Legacy labels remain
+# for backward-compatibility with issue templates and external tooling;
+# the `type:*` namespace is the source of truth for PR-level filtering.
+- name: type:feature
+  description: New functionality (conventional feat)
+  color: "a2eeef"
+
+- name: type:fix
+  description: Bug fix (conventional fix)
+  color: "d73a4a"
+
+- name: type:chore
+  description: Tooling, maintenance, routine task (conventional chore)
+  color: "c5def5"
+
+- name: type:refactor
+  description: Refactor without behaviour change
+  color: "fbca04"
+
+- name: type:docs
+  description: Documentation-only change
+  color: "0075ca"
+
+- name: type:test
+  description: Test-only change
+  color: "006b75"
+
+- name: type:perf
+  description: Performance improvement
+  color: "4b0082"
+
+- name: type:build
+  description: Build / packaging change
+  color: "5319e7"
+
+- name: type:ci
+  description: CI/CD change
+  color: "000000"
+
+# Security Labels — orthogonal axis (0–2 per PR)
+- name: security
+  description: Addresses a security advisory, CVE, or hardens security posture
+  color: "b60205"
+
+- name: security:supply-chain
+  description: Supply-chain (dependency) vulnerability remediation
+  color: "d93f0b"
+
+# Scope Labels — who the change affects (0–1 per PR)
+- name: scope:sdk-consumers
+  description: Affects downstream SDK consumers (uvx aignostics / uv add aignostics)
+  color: "0e8a16"
+
+- name: scope:dev-only
+  description: Affects only our dev/CI env; consumers unaffected
+  color: "bfdadc"
+
+# Automation Labels
+- name: auto-merge
+  description: Eligible for auto-merge once CI is green
+  color: "0e8a16"


### PR DESCRIPTION
🛡️ Resolves [PYSDK-94](https://aignx.atlassian.net/browse/PYSDK-94) following [CC-SOP-01 Change Control](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM/pages/86802705/CC-SOP-01+Change+Control), part of our [ISO 13485-certified QMS](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM) | [Ketryx Project](https://app.ketryx.com/projects/KXPRJ2Q4PA8AADY975SFMKF276TYV75).

## What

Adds **16 new labels** to `.github/labels.yml` across five axes (2 `sop:*` + 9 `type:*` + 2 `security:*` + 2 `scope:*` + 1 `auto-merge`). The existing `labels-sync.yml` workflow fires on push to `main` touching this file, so the labels become live as soon as this PR merges. (The labels were also pre-created via `gh label create` so today's in-flight PRs could be retroactively labelled — the YAML change makes that durable and source-of-truth.)

### Added labels

**SOP axis (mandatory, one per PR) — 2:**
- `sop:pr-sop-01` — PR-SOP-01 Problem Resolution (bug / anomaly fix)
- `sop:cc-sop-01` — CC-SOP-01 Change Control (feature / planned change)

**Type axis (one per PR, rounds out conventional commits) — 9:**
- `type:feature`, `type:fix`, `type:chore`, `type:refactor`, `type:docs`, `type:test`, `type:perf`, `type:build`, `type:ci`

**Security axis (orthogonal, 0–2 per PR) — 2:**
- `security` — addresses a security advisory / CVE
- `security:supply-chain` — dependency-chain vulnerability remediation

**Scope axis (orthogonal, 0–1 per PR) — 2:**
- `scope:sdk-consumers` — affects downstream SDK consumers (`uvx aignostics` / `uv add aignostics`)
- `scope:dev-only` — affects only our dev/CI env

**Automation — 1:**
- `auto-merge` — eligible for auto-merge once CI is green

### Rejected during design review

- `release:breaking` / `release:no-impact` — semver in the tag already carries this signal
- `security:sbom` — too fine-grained; SBOM changes roll up into either `type:chore` or `security:supply-chain`
- `scope:docs-only` — duplicates `type:docs`
- `scope:infra` — overlaps `type:chore` + `type:ci`
- Retiring legacy `bug` / `documentation` / `enhancement` — they remain as GitHub defaults for issue templates

## Why

PRs previously had no SOP trail, only three `type:*`-equivalent labels (`bug`/`documentation`/`enhancement`), no security axis, no consumer-vs-dev scope, and no auto-merge marker. Reviewers now have clean label-sidebar filters for every axis that matters for compliance and day-to-day triage.

## Test plan

- [x] Labels created and applied to 11 in-flight PRs (see `sop:*`, `type:*`, `scope:*` on PRs #570–#580)
- [ ] CI green
- [ ] `labels-sync.yml` fires on merge to main and confirms all 16 labels

## Follow-up (separate PRs)

The `cc-sop-01`, `pr-sop-01`, and `audit-vulnerabilities` skills will be updated to apply matching `sop:*`, `type:*`, `security:*`, `scope:*` labels automatically on PR creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PYSDK-94]: https://aignx.atlassian.net/browse/PYSDK-94?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ