### PR TITLE
chore: enable aignostics/claude-plugins qms plugin project-wide [PYSDK-96]

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -23,9 +23,7 @@
     ]
   },
   "enableAllProjectMcpServers": true,
-  "enabledMcpjsonServers": [
-    "context7"
-  ],
+  "enabledMcpjsonServers": [],
   "extraKnownMarketplaces": {
     "aignostics-claude-plugins": {
       "source": {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,41 @@
+{
+  "permissions": {
+    "allow": [
+      "mcp__claude_ai_Atlassian__getConfluencePage",
+      "mcp__claude_ai_Atlassian__getVisibleJiraProjects",
+      "mcp__claude_ai_Atlassian__getAccessibleAtlassianResources",
+      "mcp__claude_ai_Atlassian__getCompassComponent",
+      "mcp__claude_ai_Atlassian__getJiraIssue",
+      "mcp__claude_ai_Atlassian__searchJiraIssuesUsingJql",
+      "mcp__claude_ai_Atlassian__search",
+      "mcp__claude_ai_Atlassian__getConfluenceSpaces",
+      "mcp__claude_ai_Atlassian__getPagesInConfluenceSpace",
+      "mcp__claude-in-chrome__read_page",
+      "mcp__claude-in-chrome__get_page_text",
+      "mcp__claude-in-chrome__tabs_context_mcp",
+      "Bash(make lint)",
+      "Bash(make lint_fix)",
+      "Bash(make test_unit)",
+      "Bash(make test_integration)",
+      "Bash(make audit)",
+      "Bash(gh label list *)",
+      "Bash(gh search *)"
+    ]
+  },
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": [
+    "context7"
+  ],
+  "extraKnownMarketplaces": {
+    "aignostics-claude-plugins": {
+      "source": {
+        "source": "github",
+        "repo": "aignostics/claude-plugins"
+      },
+      "autoUpdate": true
+    }
+  },
+  "enabledPlugins": {
+    "qms@aignostics-claude-plugins": true
+  }
+}


### PR DESCRIPTION
🛡️ Implements [PYSDK-96](https://aignx.atlassian.net/browse/PYSDK-96) following [CC-SOP-01 Change Control](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM/pages/86802705/CC-SOP-01+Change+Control), part of our [ISO 13485-certified QMS](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM) | [Ketryx Project](https://app.ketryx.com/projects/KXPRJ2Q4PA8AADY975SFMKF276TYV75)

## Summary

This is the **first commit of `.claude/settings.json` to git** — until now, every contributor had their own uncommitted local copy, which is exactly the skill-drift problem this PR is fixing. The committed file is the canonical team-wide configuration.

What the file does:

- **`extraKnownMarketplaces.aignostics-claude-plugins`** — registers the `github:aignostics/claude-plugins` marketplace with `autoUpdate: true` so the team's SOP skills propagate without a per-repo PR each time (see reasoning below).
- **`enabledPlugins["qms@aignostics-claude-plugins"]: true`** — auto-installs the QMS plugin (cc-sop-01, pr-sop-01, sw-sop-01, audit-vulnerabilities, jira-api-conventions, pr-labels) for every contributor.
- **`permissions.allow`** — pre-approves the read-only Atlassian/Claude-in-Chrome MCP tools and the `make`/`gh label`/`gh search` shell commands that SOP workflows run constantly. Reduces permission-prompt fatigue without granting anything destructive.
- **`enableAllProjectMcpServers: true`** — trusts any MCP server registered in the repo's `.mcp.json`. Currently `.mcp.json` is empty, so this does nothing today; future additions will arrive via a reviewed PR that edits `.mcp.json`, so the trust boundary is still gated by code review.
- **`enabledMcpjsonServers: []`** — empty; no project-level MCP servers are auto-enabled today.

## Why

Replaces per-engineer `~/.claude/skills/*.md` installs with a marketplace install pinned to the team-owned `aignostics/claude-plugins` repo. Eliminates skill drift, makes the SOPs part of the repository contract, and lets skill fixes reach the whole team on next Claude Code startup.

## On `autoUpdate: true`

Intentional. The `qms` plugin lives in `aignostics/claude-plugins` under the same governance as this repo — every change goes through a PR in that repo, and the checked-out marketplace always resolves to the plugin's current `main` branch. Pinning to a commit SHA here would defeat the "single source of truth for SOPs" goal and create a second queue of per-repo bump PRs for every skill fix. If a specific release ever needs to be frozen, we can switch to `"ref": "v1.2.3"` then.

## On `enableAllProjectMcpServers: true`

Intentional. `.mcp.json` is the repo-level MCP manifest — adding an MCP server to it goes through a PR in this repo, visible in the diff. Auto-trusting every server listed there doesn't expand the trust boundary beyond code review; it just removes the per-contributor approval friction. Flipping this to `false` would force every contributor to approve each server individually on first encounter, with no security gain since the list was already vetted in the PR that added it.

## Test plan

- [ ] Open the repo in a fresh Claude Code session and confirm the qms plugin auto-installs from `aignostics/claude-plugins`
- [ ] Run `/cc-sop-01`, `/pr-sop-01`, `/sw-sop-01`, `/audit-vulnerabilities`, `/pr-labels` — each should be recognized as a user-invocable skill
- [ ] Verify the diff is `.claude/settings.json` only

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[PYSDK-96]: https://aignx.atlassian.net/browse/PYSDK-96?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ