### PR TITLE
fix(ci): bump Dockerfile uv pin to 0.11.7 to match pyproject uv>=0.11.6 [PYSDK-98]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.14.3-slim-trixie AS base
 FROM base AS builder
 
 # Copy in UV
-COPY --from=ghcr.io/astral-sh/uv:0.9.18 /uv /bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.7 /uv /bin/uv
 
 # We use the system interpreter managed by uv
 ENV UV_PYTHON_DOWNLOADS=0


### PR DESCRIPTION
🛡️ Resolves [PYSDK-98](https://aignx.atlassian.net/browse/PYSDK-98) following [PR-SOP-01 Problem Resolution and Non-Conforming Products](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM/pages/1225392129/PR-SOP-01+Problem+Resolution+and+Non-Conforming+Products), part of our [ISO 13485-certified QMS](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM) | [Ketryx Project](https://app.ketryx.com/projects/KXPRJ2Q4PA8AADY975SFMKF276TYV75)

## Summary

- Bump `ghcr.io/astral-sh/uv` in Dockerfile from `0.9.18` to `0.11.7`
- Fixes CI on main failing across ubuntu-latest, macos-latest, windows-latest, ubuntu-24.04-arm

## Root cause

PYSDK-93 (PR #580) bumped `uv>=0.11.6` in pyproject.toml for GHSA-pjjw-68hj-v9mw and regenerated `uv.lock` with uv 0.11.x lockfile syntax. The Dockerfile was not updated in the same PR, so the 0.9.18 uv inside the build container cannot parse the newer lockfile. Every `uv sync --frozen` inside Docker tests now fails with exit code 2.

0.11.7 matches what CI auto-installs on the host (visible in [run 24910447088](https://github.com/aignostics/python-sdk/actions/runs/24910447088) logs) and satisfies the `>=0.11.6` lower bound.

## Test plan

- [ ] CI green on ubuntu-latest
- [ ] CI green on macos-latest
- [ ] CI green on windows-latest
- [ ] CI green on ubuntu-24.04-arm

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[PYSDK-98]: https://aignx.atlassian.net/browse/PYSDK-98?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ