### PR TITLE
chore: update enabledPlugins key for QMS rename [PYSDK-99]

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -34,6 +34,6 @@
     }
   },
   "enabledPlugins": {
-    "qms@aignostics-claude-plugins": true
+    "QMS@aignostics-claude-plugins": true
   }
 }


### PR DESCRIPTION
🛡️ Implements [PYSDK-99](https://aignx.atlassian.net/browse/PYSDK-99) following [CC-SOP-01 Change Control](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM/pages/86802705/CC-SOP-01+Change+Control), part of our [ISO 13485-certified QMS](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM) | [Ketryx Project](https://app.ketryx.com/projects/KXPRJ2Q4PA8AADY975SFMKF276TYV75)

## Summary

- Rename `enabledPlugins` key in `.claude/settings.json` from `qms@aignostics-claude-plugins` to `QMS@aignostics-claude-plugins`
- Restores plugin resolution for every contributor after aignostics/claude-plugins#3 renamed the plugin identifier

## Why

[aignostics/claude-plugins#3](https://github.com/aignostics/claude-plugins/pull/3) renamed the plugin identifier `qms` → `QMS` (uppercase to match how QMS is used in prose throughout the plugin and the linked Atlassian QMSYSTEM space). The lowercase key committed here in PR #582 no longer matches any entry in the marketplace, so the plugin is effectively unreachable on main until this one-line sync lands.

## Test plan

- [ ] Open the repo in a fresh Claude Code session and verify the `QMS` plugin auto-installs
- [ ] Run `/cc-sop-01`, `/pr-sop-01`, `/sw-sop-01`, `/audit-vulnerabilities`, `/pr-labels` — all recognised as user-invocable

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[PYSDK-99]: https://aignx.atlassian.net/browse/PYSDK-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ