### PR TITLE
chore(ci): exclude .claude/worktrees from pyright + gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 # .gitignore of project Aignostics Python SDK
 
+# Claude Code agent worktrees — created locally per session, never committed.
+# Note: .claude/settings.json is intentionally tracked; only worktrees are ignored.
+.claude/worktrees/
+
 # Environment
 .env
 .env.*

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -3,6 +3,7 @@
     "exclude": [
         "**/.nox/**",
         "**/.venv/**",
+        "**/.claude/worktrees/**",
         "**/dist-packages/**",
         "**/dist_vercel/.vercel/**",
         "**/dist_native/**",


### PR DESCRIPTION
## Why

`make lint` started failing locally for anyone with an in-flight Claude Code background session in this repo. Pyright recurses into `.claude/worktrees/<session>/` (a local agent worktree directory containing a full clone with codegen output) and reports type errors from nested generated code that isn't part of our source.

Repro: any working tree where Claude Code has spawned an isolated worktree under `.claude/worktrees/`. Pyright walks the filesystem (it doesn't honour `.gitignore` or git-tracked status), sees the codegen `.py` files, fails them.

## What

Two-line fix:

- **`pyrightconfig.json`** — add `**/.claude/worktrees/**` to the `exclude` array.
- **`.gitignore`** — add `.claude/worktrees/`. Belt-and-braces. Without this, a contributor running `git add -A` could scoop the worktree dir into a commit.

## What this does NOT change

- `.claude/settings.json` is **still tracked** (it carries the project-wide plugin pin from #582 / PYSDK-96). The gitignore entry is narrow (`/worktrees/` only) and does not affect that file. Verified: `git ls-files | grep .claude` returns `.claude/settings.json` as before.
- No source-code changes; `mypy` and `ruff` weren't affected.
- `make audit` and `make test_unit` were green either way.

## Test plan

- [x] `make lint` (ruff format + check + pyright + mypy) — green on this branch
- [x] `git ls-files | grep '\.claude'` still returns `.claude/settings.json`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)