### PR TITLE
chore(ci): emit claude:review:passed/failed label from automated PR review [PYSDK-105]

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -117,6 +117,14 @@
   description: Trigger Claude Code automation
   color: "b41d8f"
 
+- name: claude:review:passed
+  description: Automated Claude PR review found no blocking issues on the current head commit
+  color: "0e8a16"
+
+- name: claude:review:failed
+  description: Automated Claude PR review found blocking issues on the current head commit
+  color: "b60205"
+
 - name: copilot
   description: GitHub Copilot related
   color: "e6dac6"

--- a/.github/workflows/claude-code-automation-pr-review.yml
+++ b/.github/workflows/claude-code-automation-pr-review.yml
@@ -214,6 +214,49 @@ jobs:
 
         Use `gh pr comment` with your Bash tool to leave your comprehensive review as a comment on the PR.
 
+        ## Machine-Readable Verdict (MANDATORY)
+
+        After posting your review comment, you MUST emit a single-label verdict on the PR. This label is consumed by branch-protection rules to gate auto-merge — it is the only deterministic signal of your review outcome.
+
+        **Verdict criteria** (all must hold for PASS):
+
+        - No blocking findings under "CRITICAL CHECKS" — i.e. no missing test markers, no coverage drop below 85%, no `make lint` failures, no conventional-commit violations.
+        - No blocking architecture or security violations under "Repository-Specific Review Areas".
+        - Suggestions / nice-to-haves do NOT block the verdict.
+
+        If any blocking finding remains: verdict is **FAIL**.
+        Otherwise: verdict is **PASS**.
+
+        **Apply the label** (the two labels are mutually exclusive — always remove the opposite one):
+
+        ```bash
+        # PASS:
+        gh pr edit ${{ github.event.pull_request.number }} \
+          --add-label "claude:review:passed" \
+          --remove-label "claude:review:failed"
+
+        # FAIL:
+        gh pr edit ${{ github.event.pull_request.number }} \
+          --add-label "claude:review:failed" \
+          --remove-label "claude:review:passed"
+        ```
+
+        Note: `--remove-label` is a no-op if the label is not present, so it is safe to always include it.
+
+        Also include the verdict as the final line of your sticky review comment, formatted exactly as:
+
+        ```
+        **Verdict**: ✅ claude:review:passed
+        ```
+
+        or
+
+        ```
+        **Verdict**: ❌ claude:review:failed
+        ```
+
+        This makes the verdict visible to humans without scrolling through all findings.
+
         ---
 
         **Remember**: This is medical device software. Insist on highest standards. Be thorough, actionable, and kind.


### PR DESCRIPTION
🛡️ Implements [PYSDK-105](https://aignx.atlassian.net/browse/PYSDK-105) — Governed by [CC-SOP-01](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM/pages/86802705/CC-SOP-01+Change+Control), part of our [ISO 13485-certified QMS](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM).

## Summary

Adds a machine-readable verdict from the automated Claude PR review so branch-protection rules can gate `auto-merge` on the review outcome without human intervention.

- Two new mutually-exclusive labels: `claude:review:passed` (green) and `claude:review:failed` (red).
- Workflow prompt (`claude-code-automation-pr-review.yml`) extended with a mandatory "Machine-Readable Verdict" final step. Claude emits PASS or FAIL based on the existing CRITICAL CHECKS criteria (test markers, coverage ≥85%, lint clean, conventional commits, architecture/security) and applies the corresponding label via `gh pr edit --add-label … --remove-label …`. The opposite label is always removed, so the labels stay mutually exclusive.

## Why

Today the automated review leaves a sticky comment but no structured verdict — a human still has to skim the comment to decide whether blocking findings remain. With the new labels, branch-protection can require both green CI **and** `claude:review:passed` before GitHub-native auto-merge fires. This unblocks fully unattended auto-merge for low-risk PRs (Renovate/Dependabot bumps, the upcoming daily audit-vulnerabilities routine remediation PRs, and other `auto-merge`-labelled changes).

## Re-emission

Every push to a PR re-runs the review (existing `synchronize` trigger), so the verdict is always tied to the current head commit. A stale `claude:review:passed` cannot persist past a new commit — the workflow flips the label on the next push.

## Risk

- ⚠️ Auto-merge based on Claude review delegates merge authority. Mitigations: (a) labels gate auto-merge only via branch protection, which still requires green CI, (b) `make lint`/`make test`/`make audit` remain primary defences, (c) the verdict is re-emitted on every push.
- ⚠️ False positives (Claude flags non-issue) → mitigated by re-review on push and human override (manually applying `claude:review:passed`).
- ⚠️ False negatives (Claude misses an issue) → same risk profile as today's sticky-comment review; CI gates remain the primary defence.

## Out of scope

- Branch-protection rule changes — those live in repo settings (Settings → Branches), configured separately.
- Other Claude workflows (interactive sessions, weekly automation) are untouched.
- No new merge automation beyond labels — GitHub-native auto-merge is reused.

## Test plan

- [x] `make lint` clean.
- [ ] CI green.
- [ ] After merge, `gh label sync` (via `labels-sync.yml`) creates the two new labels.
- [ ] Open a trivial test PR; confirm Claude applies `claude:review:passed`.
- [ ] Open a deliberately-broken PR (e.g. a test missing a category marker); confirm Claude applies `claude:review:failed`.
- [ ] Push a fix to the broken PR; confirm the label flips to `claude:review:passed` on next push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PYSDK-105]: https://aignx.atlassian.net/browse/PYSDK-105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ