### PR TITLE
chore(deps): upgrade myst-parser to v5, sphinx <10, swagger-plugin-for-sphinx to v7

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,7 @@ dev = [
     "furo>=2025.9.25",
     "git-cliff>=2.10.1,<3",
     "mypy>=1.19.0,<2",
-    "myst-parser>=4.0.1,<5",
+    "myst-parser>=5,<6",
     "nox[uv]>=2025.11.12",
     "pip-audit>=2.10.0,<3",
     "pip-licenses @ git+https://github.com/neXenio/pip-licenses.git@master", # https://github.com/raimon49/pip-licenses/pull/224
@@ -197,7 +197,7 @@ dev = [
     "pytest-xdist[psutil]>=3.8.0,<4",
     "ruff>=0.14.8,<1",
     "scalene>=2.0.1,<3",
-    "sphinx>=8.2.3,<9",
+    "sphinx>=8.2.3,<10",
     "sphinx-autobuild>=2025.8.25,<2026",
     "sphinx-click>=6.2.0,<7",
     "sphinx-copybutton>=0.5.2,<1",
@@ -208,7 +208,7 @@ dev = [
     "sphinx-toolbox>=4.1.0,<5",
     "sphinxcontrib.mermaid",  # https://github.com/mgaitan/sphinxcontrib-mermaid
     "sphinxext.opengraph>=0.9.1,<1",
-    "swagger-plugin-for-sphinx>=6.1.0,<7",
+    "swagger-plugin-for-sphinx>=7,<8",
     "tomli>=2.3.0,<3",
     "types-pyyaml>=6.0.12.20250915,<7",
     "types-requests>=2.32.4.20250913,<3",

--- a/uv.lock
+++ b/uv.lock
@@ -256,7 +256,7 @@ dev = [
     { name = "git-cliff", specifier = ">=2.10.1,<3" },
     { name = "linkify-it-py", specifier = ">=2.0.3,<3" },
     { name = "mypy", specifier = ">=1.19.0,<2" },
-    { name = "myst-parser", specifier = ">=4.0.1,<5" },
+    { name = "myst-parser", specifier = ">=5,<6" },
     { name = "nox", extras = ["uv"], specifier = ">=2025.11.12" },
     { name = "pip", specifier = ">=25.3" },
     { name = "pip-audit", specifier = ">=2.10.0,<3" },
@@ -279,7 +279,7 @@ dev = [
     { name = "pytest-xdist", extras = ["psutil"], specifier = ">=3.8.0,<4" },
     { name = "ruff", specifier = ">=0.14.8,<1" },
     { name = "scalene", specifier = ">=2.0.1,<3" },
-    { name = "sphinx", specifier = ">=8.2.3,<9" },
+    { name = "sphinx", specifier = ">=8.2.3,<10" },
     { name = "sphinx-autobuild", specifier = ">=2025.8.25,<2026" },
     { name = "sphinx-click", specifier = ">=6.2.0,<7" },
     { name = "sphinx-copybutton", specifier = ">=0.5.2,<1" },
@@ -289,7 +289,7 @@ dev = [
     { name = "sphinx-toolbox", specifier = ">=4.1.0,<5" },
     { name = "sphinxcontrib-mermaid" },
     { name = "sphinxext-opengraph", specifier = ">=0.9.1,<1" },
-    { name = "swagger-plugin-for-sphinx", specifier = ">=6.1.0,<7" },
+    { name = "swagger-plugin-for-sphinx", specifier = ">=7,<8" },
     { name = "tomli", specifier = ">=2.3.0,<3" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915,<7" },
     { name = "types-requests", specifier = ">=2.32.4.20250913,<3" },
@@ -3695,14 +3695,14 @@ wheels = [
 
 [[package]]
 name = "markdown-it-py"
-version = "3.0.0"
+version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mdurl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596, upload-time = "2023-06-03T06:41:14.443Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/f5/4ec618ed16cc4f8fb3b701563655a69816155e79e24a17b651541804721d/markdown_it_py-4.0.0.tar.gz", hash = "sha256:cb0a2b4aa34f932c007117b194e945bd74e0ec24133ceb5bac59009cda1cb9f3", size = 73070, upload-time = "2025-08-11T12:57:52.854Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528, upload-time = "2023-06-03T06:41:11.019Z" },
+    { url = "https://files.pythonhosted.org/packages/94/54/e7d793b573f298e1c9013b8c4dade17d481164aa517d1d7148619c2cedbf/markdown_it_py-4.0.0-py3-none-any.whl", hash = "sha256:87327c59b172c5011896038353a81343b6754500a08cd7a4973bb48c6d578147", size = 87321, upload-time = "2025-08-11T12:57:51.923Z" },
 ]
 
 [[package]]
@@ -4220,7 +4220,7 @@ wheels = [
 
 [[package]]
 name = "myst-parser"
-version = "4.0.1"
+version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
@@ -4230,9 +4230,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "sphinx" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/66/a5/9626ba4f73555b3735ad86247a8077d4603aa8628537687c839ab08bfe44/myst_parser-4.0.1.tar.gz", hash = "sha256:5cfea715e4f3574138aecbf7d54132296bfd72bb614d31168f48c477a830a7c4", size = 93985, upload-time = "2025-02-12T10:53:03.833Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/33/fa/7b45eef11b7971f0beb29d27b7bfe0d747d063aa29e170d9edd004733c8a/myst_parser-5.0.0.tar.gz", hash = "sha256:f6f231452c56e8baa662cc352c548158f6a16fcbd6e3800fc594978002b94f3a", size = 98535, upload-time = "2026-01-15T09:08:18.036Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/df/76d0321c3797b54b60fef9ec3bd6f4cfd124b9e422182156a1dd418722cf/myst_parser-4.0.1-py3-none-any.whl", hash = "sha256:9134e88959ec3b5780aedf8a99680ea242869d012e8821db3126d427edc9c95d", size = 84579, upload-time = "2025-02-12T10:53:02.078Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ac/686789b9145413f1a61878c407210e41bfdb097976864e0913078b24098c/myst_parser-5.0.0-py3-none-any.whl", hash = "sha256:ab31e516024918296e169139072b81592336f2fef55b8986aa31c9f04b5f7211", size = 84533, upload-time = "2026-01-15T09:08:16.788Z" },
 ]
 
 [[package]]
@@ -7409,7 +7409,7 @@ wheels = [
 
 [[package]]
 name = "swagger-plugin-for-sphinx"
-version = "6.1.0"
+version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "docutils" },
@@ -7417,9 +7417,9 @@ dependencies = [
     { name = "sphinx" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c5/f6/f614ba9486177528e954751bf1f7dc481c7f8c061134b33a78a22f549dcb/swagger_plugin_for_sphinx-6.1.0.tar.gz", hash = "sha256:baa523d9eb4538f0e26306359e3b9ca59b8f2923c56fe8b47ac3c6de63f13e4e", size = 15998, upload-time = "2025-12-01T07:21:25.934Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/14/36a4b2172fd6496c646d58dcb11c2877e09cc38e6d206eaa822dad0d0eab/swagger_plugin_for_sphinx-7.0.0.tar.gz", hash = "sha256:86a18b9ec1da2b78a80772fbd5d10549bf393b072f07da9edb5d1eaac02b8d44", size = 106931, upload-time = "2026-02-20T09:10:17.859Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/aa/486371aca5eee1f79336d9c42c73ec62061eb7d084f77b4e2e361a06e5e6/swagger_plugin_for_sphinx-6.1.0-py3-none-any.whl", hash = "sha256:c49651f31a48e8625be863ff345abd6a28a7b78c58ea2ea51daa736dbe9eb37f", size = 11255, upload-time = "2025-12-01T07:21:24.341Z" },
+    { url = "https://files.pythonhosted.org/packages/db/2d/534436c46a992b8f31bb56e591422519e218b970db1d596ff96142776613/swagger_plugin_for_sphinx-7.0.0-py3-none-any.whl", hash = "sha256:e5207f385f5061bf05eb37355a3a83794bab6e41c5404f5cf4905b90efc9684f", size = 11170, upload-time = "2026-02-20T09:10:15.479Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Consolidates and supersedes four stalled dependency PRs (#368, #388, #416, #483) into a single validated change.

- **myst-parser** `>=4.0.1,<5` → `>=5,<6`: v5.0.0 (released 2026-01-15) adds Sphinx 9 support and requires Python ≥3.11. This was the blocker Oliver identified in #368.
- **sphinx** `>=8.2.3,<9` → `>=8.2.3,<10`: Opens the upper bound to allow Sphinx 9. Stays at 8.x while Python 3.11 is in the support matrix (Sphinx 9.1 requires Python ≥3.12); will self-upgrade to 9.x once Python 3.11 is dropped.
- **swagger-plugin-for-sphinx** `>=6.1.0,<7` → `>=7,<8`: v7 drops Sphinx 7 support, consistent with our Sphinx 8/9 direction.

Closes #388, #416, #483. Supersedes #368 (the `<10` upper bound is now open; full Sphinx 9 adoption follows when Python 3.11 reaches EOL and is dropped from `requires-python`).

## Test plan

- [x] `uv sync --all-extras` resolves cleanly — myst-parser 5.0.0, swagger-plugin-for-sphinx 7.0.0 installed
- [x] `make docs` passes — html, singlehtml, latex all build with zero warnings
- [x] `make lint` passes — ruff, pyright, mypy all clean