### PR TITLE
chore: add #python-sdk-announcements to compass.yml [PYSDK-113]

### DIFF
--- a/compass.yml
+++ b/compass.yml
@@ -26,6 +26,9 @@ links:
   - name: '#python-sdk-notifications'
     type: CHAT_CHANNEL
     url: https://slack.com/app_redirect?channel=C0AUPTA5QF9
+  - name: '#python-sdk-announcements'
+    type: CHAT_CHANNEL
+    url: https://slack.com/app_redirect?channel=C08TN9NEY3Z
   - name: Ketryx Project
     type: OTHER_LINK
     url: https://app.ketryx.com/projects/KXPRJ2Q4PA8AADY975SFMKF276TYV75


### PR DESCRIPTION
🛡️ Implements [PYSDK-113](https://aignx.atlassian.net/browse/PYSDK-113) following [CC-SOP-01 Change Control](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM/pages/86802705/CC-SOP-01+Change+Control), part of our [ISO 13485-certified QMS](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM) | [Ketryx Project](https://app.ketryx.com/projects/KXPRJ2Q4PA8AADY975SFMKF276TYV75)

## Summary

- Adds the `#python-sdk-announcements` Slack channel (ID `C08TN9NEY3Z`) to the `links` section of `compass.yml`
- Makes the channel visible and clickable from the Atlassian Compass component page alongside `#python-sdk-dev` and `#python-sdk-notifications`
- No code, tests, or other configuration changed

## Test plan

- [ ] CI lint passes (config-only change, no code affected)
- [ ] Compass component page shows the new channel link after merge

[PYSDK-113]: https://aignx.atlassian.net/browse/PYSDK-113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ