### PR TITLE
chore(docs): sync supply-chain record with pyproject after #531/#553 [PYSDK-114]

### DIFF
--- a/SUPPLY_CHAIN_VULNERABILITIES.md
+++ b/SUPPLY_CHAIN_VULNERABILITIES.md
@@ -101,7 +101,7 @@ version.
 
 | Package | Constraint | Protects against | Severity | Applies to | Since |
 | --- | --- | --- | --- | --- | --- |
-| `nicegui[native]` | `>=3.9.0,<4` | [CVE-2026-21871](https://nvd.nist.gov/vuln/detail/CVE-2026-21871), [CVE-2026-21873](https://nvd.nist.gov/vuln/detail/CVE-2026-21873), [CVE-2026-21874](https://nvd.nist.gov/vuln/detail/CVE-2026-21874) (≥3.5.0); [CVE-2026-25516](https://nvd.nist.gov/vuln/detail/CVE-2026-25516) (≥3.7.0); [CVE-2026-27156](https://nvd.nist.gov/vuln/detail/CVE-2026-27156) (≥3.8.0); [CVE-2026-33332](https://nvd.nist.gov/vuln/detail/CVE-2026-33332) (≥3.9.0) | Medium | always | 2026-01-09 (≥3.5.0); 2026-04-24 raised to ≥3.9.0 |
+| `nicegui[native]` | `>=3.11.0,<4` | [CVE-2026-21871](https://nvd.nist.gov/vuln/detail/CVE-2026-21871), [CVE-2026-21873](https://nvd.nist.gov/vuln/detail/CVE-2026-21873), [CVE-2026-21874](https://nvd.nist.gov/vuln/detail/CVE-2026-21874) (≥3.5.0); [CVE-2026-25516](https://nvd.nist.gov/vuln/detail/CVE-2026-25516) (≥3.7.0); [CVE-2026-27156](https://nvd.nist.gov/vuln/detail/CVE-2026-27156) (≥3.8.0); [CVE-2026-33332](https://nvd.nist.gov/vuln/detail/CVE-2026-33332) (≥3.9.0); [CVE-2026-39844](https://nvd.nist.gov/vuln/detail/CVE-2026-39844) (≥3.10.0) | Medium | always | 2026-01-09 (≥3.5.0); 2026-04-24 raised to ≥3.9.0; 2026-04-26 raised to ≥3.11.0 (#531) |
 | `pyjwt[crypto]` | `>=2.12.0,<3` | [CVE-2026-32597](https://nvd.nist.gov/vuln/detail/CVE-2026-32597) | High | always | 2026-04-24 |
 | `requests` | `>=2.33.0,<3` | [CVE-2026-25645](https://nvd.nist.gov/vuln/detail/CVE-2026-25645) | Medium | always | 2026-03-26 |
 | `urllib3` | `>=2.6.3,<3` | [CVE-2026-21441](https://nvd.nist.gov/vuln/detail/CVE-2026-21441) | Medium | always | 2026-01-08 |
@@ -121,7 +121,7 @@ version.
 | `lxml-html-clean` | `>=0.4.4` | [CVE-2026-28348](https://nvd.nist.gov/vuln/detail/CVE-2026-28348), [CVE-2026-28350](https://nvd.nist.gov/vuln/detail/CVE-2026-28350) | Medium | always | 2026-04-24 |
 | `python-multipart` | `>=0.0.26` | [CVE-2026-24486](https://nvd.nist.gov/vuln/detail/CVE-2026-24486) (≥0.0.22); [CVE-2026-40347](https://nvd.nist.gov/vuln/detail/CVE-2026-40347) (≥0.0.26) | High | always | 2026-04-24 |
 | `protobuf` | `>=6.33.5` | [CVE-2026-0994](https://nvd.nist.gov/vuln/detail/CVE-2026-0994) | High | always | 2026-04-24 |
-| `nbconvert` | `>=7.17.1` | [CVE-2025-53000](https://nvd.nist.gov/vuln/detail/CVE-2025-53000) | High | with the `jupyter` extra | 2026-04-24 |
+| `nbconvert` | `>=7.17.1` | [CVE-2025-53000](https://nvd.nist.gov/vuln/detail/CVE-2025-53000) (≥7.17.0); [CVE-2026-39377](https://nvd.nist.gov/vuln/detail/CVE-2026-39377), [CVE-2026-39378](https://nvd.nist.gov/vuln/detail/CVE-2026-39378) (≥7.17.1) | High | with the `jupyter` extra | 2026-04-24 (≥7.17.1) |
 | `jupyter-core` | `>=5.8.1` | [CVE-2025-30167](https://nvd.nist.gov/vuln/detail/CVE-2025-30167) | High | with the `jupyter` extra | 2025-12-10 |
 | `jupyterlab` | `>=4.4.9` | [CVE-2025-59842](https://nvd.nist.gov/vuln/detail/CVE-2025-59842) | Low | with the `jupyter` extra | 2025-12-10 |
 | `marimo` | `>=0.23.0,<1` | [GHSA-2679-6mx9-h9xc](https://github.com/advisories/GHSA-2679-6mx9-h9xc) | Medium | with the `marimo` extra | 2026-04-24 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,7 @@ jupyter = [
     # WARNING: one cannot negate or downgrade a dependency required here. use override-dependencies for that.
     "jupyter-core>=5.8.1",              # CVE-2025-30167
     "jupyterlab>=4.4.9",                # CVE-2025-59842
-    "nbconvert>=7.17.1",                # CVE-2025-53000 (>=7.17.0, Dependabot #424); Dependabot #553 raised to 7.17.1
+    "nbconvert>=7.17.1",                # CVE-2025-53000 (>=7.17.0, Dependabot #424); CVE-2026-39377, CVE-2026-39378 (>=7.17.1, Dependabot #553)
 ]
 marimo = [
     "cloudpathlib>=0.23.0,<1",


### PR DESCRIPTION
🛡️ Resolves [PYSDK-114](https://aignx.atlassian.net/browse/PYSDK-114). Governed by [PR-SOP-01 Problem Resolution and Non-Conforming Products](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM/pages/1225392129/PR-SOP-01+Problem+Resolution+and+Non-Conforming+Products).

## Why this PR exists

`make audit` on `main` is green and every `pyproject.toml` lower bound correctly protects downstream consumers — including for the two CVE-driven bot bumps in this PR's scope. But the auditable record in `SUPPLY_CHAIN_VULNERABILITIES.md` and one inline annotation in `pyproject.toml` lag behind reality after merges of #531 (nicegui) and #553 (nbconvert). Reviewers reading the doc would see a snapshot inconsistent with the metadata published to PyPI.

This PR closes that gap. It is a pure record-keeping fix — **no version constraint changes, no `uv lock` regeneration, no consumer-visible behaviour change.**

## Key property: no dependency was upgraded

Every existing lower bound in `pyproject.toml` is preserved. The diff only:

- raises one row's `Constraint` column in `SUPPLY_CHAIN_VULNERABILITIES.md` to match what is already in `pyproject.toml`
- extends two rows' `Protects against` columns with CVE ids whose fixes the existing bound already enforces
- rewrites one inline `# CVE-…` annotation in `pyproject.toml` to name the CVEs whose fixes the bound already enforces

## What changed

### `SUPPLY_CHAIN_VULNERABILITIES.md` — `nicegui[native]` row (line 104)

- Constraint column: `>=3.9.0,<4` → `>=3.11.0,<4` (matches `pyproject.toml` after #531).
- Protects-against list: append `CVE-2026-39844 (>=3.10.0)` (CVSS 5.9 Medium).
- Since column: append `; 2026-04-26 raised to >=3.11.0 (#531)`.

### `SUPPLY_CHAIN_VULNERABILITIES.md` — `nbconvert` row (line 124)

- Protects-against list: extended with `CVE-2026-39377 (>=7.17.1)` and `CVE-2026-39378 (>=7.17.1)` (both CVSS 6.5 Medium). Existing `CVE-2025-53000 (>=7.17.0)` reformatted to match the rest of the table's "since-which-version" convention.
- Severity stays High (max across the protected CVEs).

### `pyproject.toml` — `nbconvert` inline annotation (line 158)

```diff
- "nbconvert>=7.17.1",  # CVE-2025-53000 (>=7.17.0, Dependabot #424); Dependabot #553 raised to 7.17.1
+ "nbconvert>=7.17.1",  # CVE-2025-53000 (>=7.17.0, Dependabot #424); CVE-2026-39377, CVE-2026-39378 (>=7.17.1, Dependabot #553)
```

## Accepted advisories — unchanged

The only entry in the **Active acceptances** table is `CVE-2026-3219` (pip archive type confusion, dev-only, no upstream fix released yet). Re-verified this run: still warranted; pip 26.0.1 is the latest, fix is in unreleased pip 26.1.

## Auditable record — changes to `SUPPLY_CHAIN_VULNERABILITIES.md`

**Active acceptances** — added: none. — removed: none. — changed: none.

**Enforced lower bounds — raised**
- `nicegui[native]` `>=3.9.0,<4` → `>=3.11.0,<4` — adds documented protection against `CVE-2026-39844` (Medium).

**Enforced lower bounds — annotation only (no version change)**
- `nbconvert` `>=7.17.1`: `Protects against` extended with `CVE-2026-39377` (Medium) and `CVE-2026-39378` (Medium); severity stays High.

## Test plan

- [x] `make audit` green (only the existing `CVE-2026-3219` ignore fires; still justified)
- [x] `make lint` green
- [x] `make test_unit` green
- [x] Manual cross-check: every CVE/GHSA id in updated `SUPPLY_CHAIN_VULNERABILITIES.md` rows matches an inline `# CVE-…` annotation in `pyproject.toml` and vice versa
- [x] Manual cross-check: every `pyproject.toml` lower bound covered by an updated row equals or exceeds the doc-row constraint

## Out of scope

- New CVE remediation — none surfaced this run.
- Sort-order rot of the **Enforced lower bounds** table (rows from `2025-12-10` interleaved with `2026-04-24`) — pre-existing, not introduced here. A separate audit-skill enhancement is being requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PYSDK-114]: https://aignx.atlassian.net/browse/PYSDK-114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ