### PR TITLE
fix(deps): bump pip lower bound to >=26.1 for CVE-2026-3219 [PYSDK-115]

### DIFF
--- a/SUPPLY_CHAIN_VULNERABILITIES.md
+++ b/SUPPLY_CHAIN_VULNERABILITIES.md
@@ -75,7 +75,7 @@ under which the acceptance expires.
 
 | Advisory | Package (affected) | Severity | Applies to | Downstream exposure | Published | Accepted | Revisit by | Fix status | Rationale | Removal condition | Accepted via |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| [GHSA-58qw-9mgm-455v](https://github.com/advisories/GHSA-58qw-9mgm-455v) / [CVE-2026-3219](https://nvd.nist.gov/vuln/detail/CVE-2026-3219) — pip archive type confusion (tar+ZIP concatenation) | `pip` ≤ 26.0.1 | CVSS 4.6 Moderate (CWE-434) | dev only | **None** — `pip` is not shipped as a dependency of `aignostics`; consumers use their own pip. | 2026-04-20 | 2026-04-24 | 2026-05-24 | Fix merged in [pypa/pip#13870](https://github.com/pypa/pip/pull/13870) for milestone `26.1`; not yet released | Exploitation requires `pip install` on an attacker-crafted dual-format archive; aignostics installs only from PyPI and signed GitHub release artifacts. | pip `26.1` (or later) is released on PyPI. Raise the dev-only `pip>=25.3` lower bound to `pip>=26.1` with a `# CVE-2026-3219` comment and remove the ignore. | [PYSDK-93](https://aignx.atlassian.net/browse/PYSDK-93) |
+| _No active acceptances. All known advisories that affect aignostics or its dependencies have an upstream fix that is reflected as an enforced lower bound below._ | — | — | — | — | — | — | — | — | — | — | — |
 
 "Revisit by" is a soft deadline: when it passes, we re-check whether the
 upstream fix landed or whether a newer advisory superseded this one. For
@@ -101,6 +101,7 @@ version.
 
 | Package | Constraint | Protects against | Severity | Applies to | Since |
 | --- | --- | --- | --- | --- | --- |
+| `pip` | `>=26.1` | [CVE-2025-8869](https://nvd.nist.gov/vuln/detail/CVE-2025-8869) (≥25.3); [CVE-2026-3219](https://nvd.nist.gov/vuln/detail/CVE-2026-3219) / [GHSA-58qw-9mgm-455v](https://github.com/advisories/GHSA-58qw-9mgm-455v) (≥26.1, [pypa/pip#13870](https://github.com/pypa/pip/pull/13870)) | Medium | dev only | 2026-04-01 (>=5.3 — ineffective); 2026-04-24 raised to ≥25.3; 2026-04-27 raised to ≥26.1 |
 | `nicegui[native]` | `>=3.11.0,<4` | [CVE-2026-21871](https://nvd.nist.gov/vuln/detail/CVE-2026-21871), [CVE-2026-21873](https://nvd.nist.gov/vuln/detail/CVE-2026-21873), [CVE-2026-21874](https://nvd.nist.gov/vuln/detail/CVE-2026-21874) (≥3.5.0); [CVE-2026-25516](https://nvd.nist.gov/vuln/detail/CVE-2026-25516) (≥3.7.0); [CVE-2026-27156](https://nvd.nist.gov/vuln/detail/CVE-2026-27156) (≥3.8.0); [CVE-2026-33332](https://nvd.nist.gov/vuln/detail/CVE-2026-33332) (≥3.9.0); [CVE-2026-39844](https://nvd.nist.gov/vuln/detail/CVE-2026-39844) (≥3.10.0) | Medium | always | 2026-01-09 (≥3.5.0); 2026-04-24 raised to ≥3.9.0; 2026-04-26 raised to ≥3.11.0 (#531) |
 | `pyjwt[crypto]` | `>=2.12.0,<3` | [CVE-2026-32597](https://nvd.nist.gov/vuln/detail/CVE-2026-32597) | High | always | 2026-04-24 |
 | `requests` | `>=2.33.0,<3` | [CVE-2026-25645](https://nvd.nist.gov/vuln/detail/CVE-2026-25645) | Medium | always | 2026-03-26 |
@@ -125,7 +126,6 @@ version.
 | `jupyter-core` | `>=5.8.1` | [CVE-2025-30167](https://nvd.nist.gov/vuln/detail/CVE-2025-30167) | High | with the `jupyter` extra | 2025-12-10 |
 | `jupyterlab` | `>=4.4.9` | [CVE-2025-59842](https://nvd.nist.gov/vuln/detail/CVE-2025-59842) | Low | with the `jupyter` extra | 2025-12-10 |
 | `marimo` | `>=0.23.0,<1` | [GHSA-2679-6mx9-h9xc](https://github.com/advisories/GHSA-2679-6mx9-h9xc) | Medium | with the `marimo` extra | 2026-04-24 |
-| `pip` | `>=25.3` | [CVE-2025-8869](https://nvd.nist.gov/vuln/detail/CVE-2025-8869) | Medium | dev only | 2026-04-01 (>=5.3 — ineffective); 2026-04-24 raised to ≥25.3 |
 | `uv` | `>=0.11.6` | [CVE-2025-54368](https://nvd.nist.gov/vuln/detail/CVE-2025-54368), [GHSA-w476-p2h3-79g9](https://github.com/advisories/GHSA-w476-p2h3-79g9), [GHSA-pqhf-p39g-3x64](https://github.com/advisories/GHSA-pqhf-p39g-3x64) (≥0.9.7); [GHSA-pjjw-68hj-v9mw](https://github.com/advisories/GHSA-pjjw-68hj-v9mw) (≥0.11.6) | Medium | dev only | 2025-12-10 (≥0.9.7); 2026-04-24 raised to ≥0.11.6 |
 | `pytest` | `>=9.0.3,<10` | [CVE-2025-71176](https://nvd.nist.gov/vuln/detail/CVE-2025-71176) | Medium | dev only | 2026-04-24 |
 | `virtualenv` | `>=20.36.1` | [pypa/virtualenv#3013](https://github.com/pypa/virtualenv/pull/3013) TOCTOU fix; bundles filelock ≥3.20.1 for [CVE-2025-68146](https://nvd.nist.gov/vuln/detail/CVE-2025-68146) | Medium | dev only | 2026-04-24 |

--- a/noxfile.py
+++ b/noxfile.py
@@ -155,8 +155,6 @@ def audit(session: nox.Session) -> None:
             "json",
             "-o",
             "reports/vulnerabilities.json",
-            "--ignore-vuln",
-            "CVE-2026-3219",  # pip archive type confusion; fix in unreleased 26.1. See SUPPLY_CHAIN_VULNERABILITIES.md
         )
     except CommandFailed:
         _format_json_with_jq(session, "reports/vulnerabilities.json")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -216,7 +216,7 @@ dev = [
     "watchdog>=6.0.0,<7",
     # Transitive overrides
     # WARNING: one cannot negate or downgrade a dependency required here. use override-dependencies for that.
-    "pip>=25.3",                        # CVE-2025-8869 (>=25.3). CVE-2026-3219 (fix in 26.1, unreleased) accepted via --ignore-vuln; see SUPPLY_CHAIN_VULNERABILITIES.md.
+    "pip>=26.1",                        # CVE-2025-8869 (Medium, >=25.3); CVE-2026-3219 (Medium, >=26.1, released 2026-04-26 via pypa/pip#13870)
     "uv>=0.11.6",                       # CVE-2025-54368, GHSA-w476-p2h3-79g9, GHSA-pqhf-p39g-3x64 (>=0.9.7); GHSA-pjjw-68hj-v9mw (>=0.11.6, Renovate #536)
     "fonttools>=4.60.2",                # CVE-2025-66034 (GHSA-768j-98cg-p3fv), dep of matplotlib
     "virtualenv>=20.36.1",              # pypa/virtualenv#3013 TOCTOU in app_data/lock dir; bundles filelock>=3.20.1 for CVE-2025-68146; transitive via nox/pre-commit

--- a/uv.lock
+++ b/uv.lock
@@ -265,7 +265,7 @@ dev = [
     { name = "mypy", specifier = ">=1.19.0,<2" },
     { name = "myst-parser", specifier = ">=5,<6" },
     { name = "nox", extras = ["uv"], specifier = ">=2025.11.12" },
-    { name = "pip", specifier = ">=25.3" },
+    { name = "pip", specifier = ">=26.1" },
     { name = "pip-audit", specifier = ">=2.10.0,<3" },
     { name = "pip-licenses", git = "https://github.com/neXenio/pip-licenses.git?rev=master" },
     { name = "pre-commit", specifier = ">=4.5.0,<5" },


### PR DESCRIPTION
🛡️ Resolves [PYSDK-115](https://aignx.atlassian.net/browse/PYSDK-115). Governed by [PR-SOP-01 Problem Resolution and Non-Conforming Products](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM/pages/1225392129/PR-SOP-01+Problem+Resolution+and+Non-Conforming+Products).

Opened by the `pysdk-audit-daily` routine on 2026-04-27.

## Why this PR exists

`pip-audit` scans `uv.lock`. **Downstream consumers don't see our `uv.lock`** — they resolve against the `[project]` / `[dependency-groups]` metadata we publish. A green `make audit` therefore proves only that our dev/CI env is clean, not that consumers are protected. Renovate and Dependabot bump `uv.lock` but do not raise lower bounds in `pyproject.toml`, so their merged PRs close the dev/CI gap without closing the downstream gap.

The most recent `uv.lock` maintenance ([#604](https://github.com/aignostics/python-sdk/pull/604), merged 2026-04-27 08:07 UTC) brought pip 26.1 into the lockfile — the patched release for [CVE-2026-3219](https://nvd.nist.gov/vuln/detail/CVE-2026-3219) ([pypa/pip#13870](https://github.com/pypa/pip/pull/13870), released 2026-04-26). Until now, that advisory was carried as an **active acceptance** in `SUPPLY_CHAIN_VULNERABILITIES.md` and suppressed via `--ignore-vuln CVE-2026-3219` in `noxfile.py`, with the documented removal condition: *"pip 26.1 (or later) is released on PyPI. Raise the dev-only `pip>=25.3` lower bound to `pip>=26.1` … and remove the ignore."*

That condition is now met. This PR satisfies it.

## Key property: no dependency was upgraded

The new lower bound `pip>=26.1` is **`≤` the currently-locked version** (`26.1 == 26.1`). `uv lock` records the tighter constraint without shifting any resolved version, so dev/CI behaves identically to `main`. Behavioural regression risk equals a comment-only change.

```diff
diff --git a/uv.lock b/uv.lock
@@ -265,7 +265,7 @@ dev = [
-    { name = "pip", specifier = ">=25.3" },
+    { name = "pip", specifier = ">=26.1" },
```

That is the only change `uv lock` produced — verified via `git diff uv.lock`.

## What changed

**Dev-only (consumers don't see this; protects our own tooling):**

```diff
-    "pip>=25.3",                        # CVE-2025-8869 (>=25.3). CVE-2026-3219 (fix in 26.1, unreleased) accepted via --ignore-vuln; …
+    "pip>=26.1",                        # CVE-2025-8869 (Medium, >=25.3); CVE-2026-3219 (Medium, >=26.1, released 2026-04-26 via pypa/pip#13870)
```

**`noxfile.py` — `--ignore-vuln` removed:**

```diff
-            "--ignore-vuln",
-            "CVE-2026-3219",  # pip archive type confusion; fix in unreleased 26.1. See SUPPLY_CHAIN_VULNERABILITIES.md
```

`pip-audit` now runs ignore-free.

## Accepted advisories: re-verified

The daily re-verification loop runs `pip-audit` without each ignore in turn and removes any ignore that no longer fires.

| Advisory | Result | Action |
| --- | --- | --- |
| [CVE-2026-3219](https://nvd.nist.gov/vuln/detail/CVE-2026-3219) (pip) | No longer fires (pip 26.1 is locked) | Removed from `noxfile.py`; row moved from active acceptances to enforced lower bounds. |

No new `--ignore-vuln` entries were added.

## Docs + tooling

**Plain-language summary of changes to `SUPPLY_CHAIN_VULNERABILITIES.md`** (keyed off row identity, not a syntactic diff):

**Active acceptances — removed**

- `CVE-2026-3219` (`pip`): upstream fix released in pip 26.1 on 2026-04-26 and is now in `uv.lock`. Our newly-raised floor `pip>=26.1` keeps consumers off the affected versions, so the row no longer represents residual risk and moves to the enforced-lower-bounds table. The acceptances table now contains no rows; an explanatory placeholder describes that all known advisories have an enforced lower bound.

**Enforced lower bounds — raised**

- `pip` `>=25.3` → `>=26.1` — adds protection against `CVE-2026-3219` (Medium) on top of the existing `CVE-2025-8869` (Medium) protection. The combined `Since` column reads `2026-04-01 (>=5.3 — ineffective); 2026-04-24 raised to ≥25.3; 2026-04-27 raised to ≥26.1`.

No `.pre-commit-config.yaml` or `[tool.uv] required-version` changes are needed (the bump is to pip, not uv).

## Test plan

- [x] `make audit` green (now ignore-free)
- [x] `make lint` green (ruff format/check, pyright, mypy)
- [x] `make test_unit` green
- [x] `git diff uv.lock` shows only the `pip` specifier change in `[package.metadata]`; no `[[package]]` version block was touched (programmatic check that no dependency was upgraded)
- [x] Step 1d.2 re-run: zero drift between `pyproject.toml` lower bounds and `SUPPLY_CHAIN_VULNERABILITIES.md` after this PR (every CVE-annotated bound has a matching row, every row has a matching bound)
- [x] Cross-check: every `--ignore-vuln` in `noxfile.py` has a row in the acceptances table (post-PR: zero ignores, zero acceptance rows — they match)

## Out of scope

- 30-day bot-PR floor-sync sweep (Step 1d.1) was performed during the audit; no other gaps were found between recent Renovate/Dependabot merges and our published floors.
- This PR does not pin `pip` to an upper bound; consumers can still receive future patch / minor releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PYSDK-115]: https://aignx.atlassian.net/browse/PYSDK-115?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ