### PR TITLE
ci: fix PR review workflow re-triggered by claude:review verdict labels [PYSDK-116]

### DIFF
--- a/.github/workflows/claude-code-automation-pr-review.yml
+++ b/.github/workflows/claude-code-automation-pr-review.yml
@@ -12,7 +12,8 @@ concurrency:
 jobs:
   claude-review:
     if: |
-      contains(github.event.pull_request.labels.*.name, 'claude') ||
+      (github.event.action == 'labeled' && github.event.label.name == 'claude') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'claude')) ||
       github.event.action == 'ready_for_review'
     uses: ./.github/workflows/_claude-code.yml
     with:


### PR DESCRIPTION
🛡️ Implements [PYSDK-116](https://aignx.atlassian.net/browse/PYSDK-116) following [CC-SOP-01 Change Control](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM/pages/86802705/CC-SOP-01+Change+Control), part of our [ISO 13485-certified QMS](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM) | [Ketryx Project](https://app.ketryx.com/projects/KXPRJ2Q4PA8AADY975SFMKF276TYV75)

## Summary

- The `claude-code-automation-pr-review.yml` workflow was re-triggered whenever Claude added a `claude:review:passed` or `claude:review:failed` verdict label, because the `labeled` event fired and `contains(labels.*.name, 'claude')` returned true (the original `claude` trigger label was still on the PR).
- Fix: for `labeled` events check `github.event.label.name == 'claude'` (exact match on the newly added label); all other event types (`opened`, `synchronize`, `reopened`) and the `ready_for_review` path are unchanged.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge, add a `claude` label to a PR and verify the review workflow triggers once
- [ ] Verify adding `claude:review:passed` or `claude:review:failed` no longer re-triggers the workflow

[PYSDK-116]: https://aignx.atlassian.net/browse/PYSDK-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ