### PR TITLE
chore: add Playwright MCP server config to .mcp.json [PYSDK-117]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,9 +96,6 @@ scalene-profile.html
 # Nicegui
 .nicegui
 
-# MCP
-.mcp.json
-
 # Application specific
 data/**
 !data/.keep 

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp@latest"]
+    }
+  }
+}


### PR DESCRIPTION
🛡️ Implements [PYSDK-117](https://aignx.atlassian.net/browse/PYSDK-117) following [CC-SOP-01 Change Control](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM/pages/86802705/CC-SOP-01+Change+Control), part of our [ISO 13485-certified QMS](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM) | [Ketryx Project](https://app.ketryx.com/projects/KXPRJ2Q4PA8AADY975SFMKF276TYV75)

## Summary

- Remove `.mcp.json` from `.gitignore` so the file becomes a tracked repo artefact (per Claude Code project-scope MCP convention).
- Add `.mcp.json` at the repo root with a single `playwright` server entry: `npx @playwright/mcp@latest` over stdio.
- Pure dev-tooling change — no SDK runtime, no published package contents, no CI workflow, no test suite, no docs touched. Does **not** modify the SDK's own auto-discovered MCP server (`aignostics.utils._mcp` / `aignostics mcp run`); that one stays exactly as-is.

## Test plan

- [x] `make lint` passes locally (pre-push hook).
- [ ] CI lint job green.
- [ ] CI test matrix green (Python 3.11–3.14, unit + integration + e2e).
- [ ] CI audit job green.
- [ ] SonarCloud — no new issues, no unreviewed hotspots.
- [ ] Manual smoke (informational, not a CI gate): on next Claude Code session start, `.mcp.json` is detected, the playwright server is offered as a project-scope MCP for one-time approval, and `mcp__playwright__*` tools are then available in the tool list.

----
Posted by Claude claude-opus-4-7 via Claude Code, applying skills cc-sop-01 on behalf of Helmut Hoffer von Ankershoffen

[PYSDK-117]: https://aignx.atlassian.net/browse/PYSDK-117?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ