### PR TITLE
fix(ci): remove redundant git-cliff output config to fix publish-release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -458,7 +458,6 @@ owner = "aignostics"
 repo = "python-sdk"
 
 [tool.git-cliff.changelog]
-output = "CHANGELOG.md"
 render = true
 # template for the changelog header
 header = """


### PR DESCRIPTION
**Why?**
The `publish-release` workflow was failing with `git-cliff` error: `'-o' and '-p' can only be used together if they point to different files`. The `[tool.git-cliff.changelog]` section in `pyproject.toml` sets `output = "CHANGELOG.md"` (implicitly passing `-o`), while the workflow passes `--prepend CHANGELOG.md` (`-p`) explicitly — both pointing to the same file, which git-cliff now rejects.

**How?**
Removed the `output = "CHANGELOG.md"` line from `[tool.git-cliff.changelog]` in `pyproject.toml`. The workflow already controls the output path explicitly via `--prepend` and `--output` flags in each branch of the conditional, so the config-level default is redundant.