### PR TITLE
fix(deps): bump uv lower bound to >=0.11.6 for GHSA-pjjw-68hj-v9mw

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,8 +207,8 @@ dev = [
     "watchdog>=6.0.0,<7",
     # Transitive overrides
     # WARNING: one cannot negate or downgrade a dependency required here. use override-dependencies for that.
-    "pip>=26.1",                        # CVE-2025-8869
-    "uv>=0.9.7",                        # CVE-2025-54368, GHSA-w476-p2h3-79g9, GHSA-pqhf-p39g-3x64
+    "pip>=26.1",                        # CVE-2025-8869 (Medium, >=25.3); CVE-2026-3219 (Medium, >=26.1, released 2026-04-26 via pypa/pip#13870)
+    "uv>=0.11.6",                       # CVE-2025-54368, GHSA-w476-p2h3-79g9, GHSA-pqhf-p39g-3x64 (>=0.9.7); GHSA-pjjw-68hj-v9mw (>=0.11.6, Renovate #536)
     "fonttools>=4.60.2",                # CVE-2025-66034 (GHSA-768j-98cg-p3fv), dep of matplotlib
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -276,7 +276,7 @@ dev = [
     { name = "tomli", specifier = ">=2.3.0,<3" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915,<7" },
     { name = "types-requests", specifier = ">=2.32.4.20250913,<3" },
-    { name = "uv", specifier = ">=0.11.6" },
+    { name = "uv", specifier = ">=0.9.7" },
     { name = "watchdog", specifier = ">=6.0.0,<7" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -276,7 +276,7 @@ dev = [
     { name = "tomli", specifier = ">=2.3.0,<3" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915,<7" },
     { name = "types-requests", specifier = ">=2.32.4.20250913,<3" },
-    { name = "uv", specifier = ">=0.9.7" },
+    { name = "uv", specifier = ">=0.11.6" },
     { name = "watchdog", specifier = ">=6.0.0,<7" },
 ]
 


### PR DESCRIPTION
**Why?**
PR #620 (`release/v1.3.0` → `main`) is blocked by a merge conflict caused by `main` bumping `uv` to `>=0.11.6` (fixing GHSA-pjjw-68hj-v9mw) after the release branch was cut.

**How?**
Applies the same `uv>=0.11.6` lower bound and extended CVE comment to `release/v1.3.0` directly, so both sides of the merge become identical and git resolves the conflict automatically.