### PR TITLE
fix(ci): fix slack release announcement JSON payload

### DIFF
--- a/.github/workflows/_package-publish.yml
+++ b/.github/workflows/_package-publish.yml
@@ -237,19 +237,23 @@ jobs:
           release: ${{ github.ref_name }}
 
       - name: Convert release notes from Markdown to Slack mrkdwn
-        id: slack-notes
         shell: bash
         env:
           GIT_CLIFF_CONTENT: ${{ steps.git-cliff.outputs.content }}
         run: |
           # Convert Markdown links [text](url) to Slack mrkdwn <url|text>
           # Convert bold **text** to *text*
-          SLACK_RELEASE_NOTES=$(printf '%s\n' "$GIT_CLIFF_CONTENT" | \
+          NOTES_CONVERTED=$(printf '%s\n' "$GIT_CLIFF_CONTENT" | \
             sed -E 's/\[([^]]+)\]\(([^)]+)\)/<\2|\1>/g' | \
             sed -E 's/\*\*([^*]+)\*\*/*\1*/g')
-          echo "content<<SLACKEOF" >> "$GITHUB_OUTPUT"
-          echo "$SLACK_RELEASE_NOTES" >> "$GITHUB_OUTPUT"
-          echo "SLACKEOF" >> "$GITHUB_OUTPUT"
+          RELEASE_URL="${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ github.ref_name }}"
+          if [ "$(printf '%s' "$NOTES_CONVERTED" | wc -c)" -gt 2700 ]; then
+            NOTES_TRUNCATED=$(printf '%s' "$NOTES_CONVERTED" | head -c 2700)
+            NOTES_CONVERTED="${NOTES_TRUNCATED}"$'\n'"...<${RELEASE_URL}|Read full release notes>"
+          fi
+          # JSON-escape: backslashes first, then double quotes, then collapse newlines to \n
+          NOTES=$(printf '%s' "$NOTES_CONVERTED" | sed 's/\\/\\\\/g' | sed 's/"/\\"/g' | sed ':a;N;$!ba;s/\n/\\n/g')
+          echo "SLACK_RELEASE_NOTES=$NOTES" >> "$GITHUB_ENV"
 
       - name: Release Announcement
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95 # v3.0.1
@@ -257,10 +261,12 @@ jobs:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_RELEASE_ANNOUNCEMENT }}
           webhook-type: webhook-trigger
           payload: |
-            "repository": "${{ github.repository }}",
-            "version": "${{ steps.git-cliff.outputs.version }}",
-            "release_notes": ${{ steps.slack-notes.outputs.content }},
-            "channel_id": "${{ secrets.SLACK_CHANNEL_ID_RELEASE_ANNOUNCEMENT }}"
+            {
+              "repository": "${{ github.repository }}",
+              "version": "${{ steps.git-cliff.outputs.version }}",
+              "release_notes": "${{ env.SLACK_RELEASE_NOTES }}",
+              "channel_id": "${{ secrets.SLACK_CHANNEL_ID_RELEASE_ANNOUNCEMENT }}"
+            }
 
       - name: Allow other workflows to trigger on release
         env:


### PR DESCRIPTION
**Why?**
The `publish-release` CI job was failing on the final "Release Announcement" step with a JSON parse error. The payload block was missing enclosing `{}` braces, and the release notes content was raw multi-line markdown interpolated directly — the `#` heading character is a YAML comment marker, and unescaped newlines and quotes broke both JSON and YAML parsing by the Slack action.

**How?**
Updated the "Convert release notes" step to JSON-escape the content (escape backslashes, quotes, then collapse newlines to `\n`) via a `sed` pipeline matching the pattern used in the `foundry-python` template, storing the result in `$GITHUB_ENV`. Also added 2700-char truncation with a full-release-notes link. Fixed the `payload:` block to be a valid JSON object with the pre-escaped value referenced as a quoted JSON string.