### PR TITLE
chore(ci): disable split_commits in git-cliff config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -558,7 +558,7 @@ conventional_commits = true
 # filter out the commits that are not conventional
 filter_unconventional = true
 # process each line of a commit as an individual commit
-split_commits = true
+split_commits = false
 # regex for preprocessing the commit messages
 commit_preprocessors = [
     { pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](<REPO>/pull/${2}))" },


### PR DESCRIPTION
**Why?**
With `split_commits = true`, git-cliff treats every line of a commit body as an independent changelog entry. This caused `Co-authored-by:` trailer lines from squash-merged PRs to leak into the changelog as fake entries (e.g. "Claude Sonnet 4.6 <noreply@anthropic.com>"), and also produced duplicate entries when a commit body repeated its own subject.

**How?**
Set `split_commits = false` so git-cliff uses only the commit subject line per commit. This eliminates both the co-author leakage and the duplicate entries at their root, without needing per-pattern skip rules.