### PR TITLE
fix(ci): resolve SonarQube security issues in workflows and Dockerfile

### DIFF
--- a/.github/workflows/_claude-code.yml
+++ b/.github/workflows/_claude-code.yml
@@ -72,7 +72,7 @@ jobs:
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         shell: bash
         run: |
-          TOML_VERSION=$(uv run python -c "import tomli; print(tomli.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          TOML_VERSION=$(uv run --frozen python -c "import tomli; print(tomli.load(open('pyproject.toml', 'rb'))['project']['version'])")
           echo "Development build - Current version in pyproject.toml: $TOML_VERSION"
 
       - name: Run Claude Code (Interactive Mode)

--- a/.github/workflows/_package-publish.yml
+++ b/.github/workflows/_package-publish.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Validate installation
         shell: bash
         run: |
-          OUTPUT=$(uv run --all-extras --no-dev aignostics --help)
+          OUTPUT=$(uv run --frozen --all-extras --no-dev aignostics --help)
           if [[ "$OUTPUT" != *"built with love in Berlin"* ]]; then
           echo "Output does not contain 'built with love in Berlin'"
           exit 1
@@ -149,7 +149,7 @@ jobs:
       - name: Final smoke test
         shell: bash
         run: |
-          uv run --no-dev aignostics --help
+          uv run --frozen --no-dev aignostics --help
 
       - name: Docs
         shell: bash

--- a/.github/workflows/_scheduled-test-daily.yml
+++ b/.github/workflows/_scheduled-test-daily.yml
@@ -76,7 +76,7 @@ jobs:
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         shell: bash
         run: |
-          TOML_VERSION=$(uv run python -c "import tomli; print(tomli.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          TOML_VERSION=$(uv run --frozen python -c "import tomli; print(tomli.load(open('pyproject.toml', 'rb'))['project']['version'])")
           echo "Development build - Current version in pyproject.toml: $TOML_VERSION"
 
       - name: Create .env file
@@ -108,7 +108,7 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-            OUTPUT=$(uv run --no-dev aignostics --help)
+            OUTPUT=$(uv run --frozen --no-dev aignostics --help)
             if [[ "$OUTPUT" != *"built with love in Berlin"* ]]; then
             echo "Output does not contain 'built with love in Berlin'"
             exit 1
@@ -119,12 +119,12 @@ jobs:
         continue-on-error: true
         shell: bash
         run: |
-          uv run --no-dev aignostics --help
-          uv run --all-extras aignostics system info
-          uv run --all-extras aignostics system health
-          uv run --all-extras aignostics user whoami --mask-secrets
-          uv run --all-extras aignostics application list
-          uv run --all-extras aignostics application run list --verbose --limit 1
+          uv run --frozen --no-dev aignostics --help
+          uv run --frozen --all-extras aignostics system info
+          uv run --frozen --all-extras aignostics system health
+          uv run --frozen --all-extras aignostics user whoami --mask-secrets
+          uv run --frozen --all-extras aignostics application list
+          uv run --frozen --all-extras aignostics application run list --verbose --limit 1
 
       - name: Test / Unit (multiple Python versions)
         id: unit

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -100,7 +100,7 @@ jobs:
         shell: bash
         run: |
           TAG_VERSION=${GITHUB_REF#refs/tags/v}
-          TOML_VERSION=$(uv run python -c "import tomli; print(tomli.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          TOML_VERSION=$(uv run --frozen python -c "import tomli; print(tomli.load(open('pyproject.toml', 'rb'))['project']['version'])")
           if [ "$TAG_VERSION" != "$TOML_VERSION" ]; then
             echo "Release version mismatch: Tag $TAG_VERSION != pyproject.toml $TOML_VERSION"
             exit 1
@@ -110,7 +110,7 @@ jobs:
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
         shell: bash
         run: |
-          TOML_VERSION=$(uv run python -c "import tomli; print(tomli.load(open('pyproject.toml', 'rb'))['project']['version'])")
+          TOML_VERSION=$(uv run --frozen python -c "import tomli; print(tomli.load(open('pyproject.toml', 'rb'))['project']['version'])")
           echo "Development build - Current version in pyproject.toml: $TOML_VERSION"
 
       - name: Create .env file
@@ -140,7 +140,7 @@ jobs:
       - name: Validate installation (single Python version)
         shell: bash
         run: |
-            OUTPUT=$(uv run --no-dev aignostics --help)
+            OUTPUT=$(uv run --frozen --no-dev aignostics --help)
             if [[ "$OUTPUT" != *"built with love in Berlin"* ]]; then
             echo "Output does not contain 'built with love in Berlin'"
             exit 1
@@ -149,12 +149,12 @@ jobs:
       - name: Test / Smoke (single Python version)
         shell: bash
         run: |
-          uv run --no-dev aignostics --help
-          uv run --all-extras aignostics system info
-          uv run --all-extras aignostics system health
-          uv run --all-extras aignostics user whoami --mask-secrets
-          uv run --all-extras aignostics application list
-          uv run --all-extras aignostics application run list --verbose --limit 1
+          uv run --frozen --no-dev aignostics --help
+          uv run --frozen --all-extras aignostics system info
+          uv run --frozen --all-extras aignostics system health
+          uv run --frozen --all-extras aignostics user whoami --mask-secrets
+          uv run --frozen --all-extras aignostics application list
+          uv run --frozen --all-extras aignostics application run list --verbose --limit 1
 
       # All test steps use continue-on-error: true so that every test suite
       # always runs regardless of whether earlier suites failed. This ensures

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -105,9 +105,9 @@ jobs:
           PREV_TAG="${{ steps.version.outputs.prev_tag }}"
           TAG_NAME="${{ steps.version.outputs.tag_name }}"
           if [ -n "$PREV_TAG" ]; then
-            uv run git-cliff --tag "$TAG_NAME" --prepend CHANGELOG.md "${PREV_TAG}..HEAD"
+            uv run --frozen git-cliff --tag "$TAG_NAME" --prepend CHANGELOG.md "${PREV_TAG}..HEAD"
           else
-            uv run git-cliff --tag "$TAG_NAME" --output CHANGELOG.md
+            uv run --frozen git-cliff --tag "$TAG_NAME" --output CHANGELOG.md
           fi
 
       - name: Commit changelog

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ FROM builder AS builder-slim
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --frozen --no-install-project --no-dev --no-editable
+    uv sync --frozen --no-build --no-install-project --no-dev --no-editable
 
 # Then, add the rest of the project source code and install it
 # Installing separately from its dependencies allows optimal layer caching
@@ -49,7 +49,7 @@ COPY examples /app/examples
 # Nothing yet
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev --no-editable
+    uv sync --frozen --no-dev --no-editable  # NOSONAR - local project built from trusted source; --frozen enforces lockfile hash verification
 
 
 # The all builder takes in all extras
@@ -59,7 +59,7 @@ FROM builder AS builder-all
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --frozen --no-install-project --all-extras --no-dev --no-editable
+    uv sync --frozen --no-build --no-install-project --all-extras --no-dev --no-editable
 
 # Then, add the rest of the project source code and install it
 # Installing separately from its dependencies allows optimal layer caching
@@ -78,7 +78,7 @@ COPY examples /app/examples
 COPY codegen/out/aignx /app/codegen/out/aignx
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --all-extras --no-dev --no-editable
+    uv sync --frozen --all-extras --no-dev --no-editable  # NOSONAR - local project built from trusted source; --frozen enforces lockfile hash verification
 
 
 # Base of our build targets

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,7 @@ COPY examples /app/examples
 # Nothing yet
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev --no-editable  # NOSONAR - local project built from trusted source; --frozen enforces lockfile hash verification
+    uv sync --frozen --no-dev --no-editable
 
 
 # The all builder takes in all extras
@@ -78,7 +78,7 @@ COPY examples /app/examples
 COPY codegen/out/aignx /app/codegen/out/aignx
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --all-extras --no-dev --no-editable  # NOSONAR - local project built from trusted source; --frozen enforces lockfile hash verification
+    uv sync --frozen --all-extras --no-dev --no-editable
 
 
 # Base of our build targets


### PR DESCRIPTION
**Why?**
SonarQube flagged two Medium/Major security issues across CI workflows and the Dockerfile: `uv sync` without `--no-build` (allowing potential build-script execution from source distributions) and `uv run` without `--frozen` (potentially allowing silent environment updates before running a command).

**How?**
Dockerfile stages that use `--no-install-project` install only external dependencies, so `--no-build` can safely enforce wheel-only installs there. The remaining `uv sync` issues (workflow files and Dockerfile stages that install `aignostics` itself) are marked as accepted in SonarQube — `aignostics` must be built from source as no pre-built binary distribution exists. All `uv run` calls in workflow files gain `--frozen`, making the lockfile invariant explicit at every invocation.