### PR TITLE
fix(deps): raise jupyter floors for 7 CVEs in jupyter extra [PYSDK-124]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,9 +153,11 @@ jupyter = [
     "jupyter>=1.1.1,<2",
     # Transitive overrides
     # WARNING: one cannot negate or downgrade a dependency required here. use override-dependencies for that.
-    "jupyter-core>=5.8.1",              # CVE-2025-30167
-    "jupyterlab>=4.4.9",                # CVE-2025-59842
-    "nbconvert>=7.17.1",                # CVE-2025-53000 (>=7.17.0, Dependabot #424); CVE-2026-39377, CVE-2026-39378 (>=7.17.1, Dependabot #553)
+    "jupyter-core>=5.8.1",              # CVE-2025-30167 (High)
+    "jupyterlab>=4.5.7",                # CVE-2025-59842 (Low, >=4.4.9); CVE-2026-40171 (High, >=4.5.7, Renovate #616); CVE-2026-42266 (High, >=4.5.7); CVE-2026-42557 (High, >=4.5.7)
+    "nbconvert>=7.17.1",                # CVE-2025-53000 (High, >=7.17.0, Dependabot #424); CVE-2026-39377, CVE-2026-39378 (High, >=7.17.1, Dependabot #553)
+    "notebook>=7.5.6",                  # CVE-2026-40171 (High, >=7.5.6, Dependabot #614); CVE-2026-42557 (High, >=7.5.6)
+    "jupyter-server>=2.18.0",           # CVE-2025-61669 (Medium, >=2.18.0, Dependabot #628); CVE-2026-35397 (High, >=2.18.0); CVE-2026-40110 (High, >=2.18.0); CVE-2026-40934 (Medium, >=2.18.0)
 ]
 marimo = [
     "cloudpathlib>=0.23.0,<1",

--- a/uv.lock
+++ b/uv.lock
@@ -101,8 +101,10 @@ dependencies = [
 jupyter = [
     { name = "jupyter" },
     { name = "jupyter-core" },
+    { name = "jupyter-server" },
     { name = "jupyterlab" },
     { name = "nbconvert" },
+    { name = "notebook" },
 ]
 marimo = [
     { name = "cloudpathlib" },
@@ -199,7 +201,8 @@ requires-dist = [
     { name = "jsonschema", extras = ["format-nongpl"], specifier = ">=4.25.1,<5" },
     { name = "jupyter", marker = "extra == 'jupyter'", specifier = ">=1.1.1,<2" },
     { name = "jupyter-core", marker = "extra == 'jupyter'", specifier = ">=5.8.1" },
-    { name = "jupyterlab", marker = "extra == 'jupyter'", specifier = ">=4.4.9" },
+    { name = "jupyter-server", marker = "extra == 'jupyter'", specifier = ">=2.18.0" },
+    { name = "jupyterlab", marker = "extra == 'jupyter'", specifier = ">=4.5.7" },
     { name = "loguru", specifier = ">=0.7.3,<1" },
     { name = "lxml", specifier = ">=6.1.0" },
     { name = "lxml-html-clean", specifier = ">=0.4.4" },
@@ -208,6 +211,7 @@ requires-dist = [
     { name = "matplotlib", marker = "extra == 'marimo'", specifier = ">=3.10.7,<4" },
     { name = "nbconvert", marker = "extra == 'jupyter'", specifier = ">=7.17.1" },
     { name = "nicegui", extras = ["native"], specifier = ">=3.11.0,<4" },
+    { name = "notebook", marker = "extra == 'jupyter'", specifier = ">=7.5.6" },
     { name = "openslide-bin", specifier = ">=4.0.0.10,<5" },
     { name = "openslide-python", specifier = ">=1.4.3,<2" },
     { name = "packaging", specifier = ">=26,<27" },


### PR DESCRIPTION
🛡️ Resolves [PYSDK-124](https://aignx.atlassian.net/browse/PYSDK-124) — governed by [PR-SOP-01 Problem Resolution and Non-Conforming Products](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM/pages/1225392129/PR-SOP-01+Problem+Resolution+and+Non-Conforming+Products), part of our [ISO 13485-certified QMS](https://aignx.atlassian.net/wiki/spaces/QMSYSTEM) | [Ketryx Project](https://app.ketryx.com/projects/KXPRJ2Q4PA8AADY975SFMKF276TYV75).

Opened by the `pysdk-audit-daily` cloud routine on 2026-05-07 ~07:10 UTC against `main` at `59506a28`.

## Why this PR exists

`pip-audit` (against our `uv.lock`) is currently green. That only proves our dev/CI environment is clean — it does **not** protect downstream consumers, who resolve against the `[project]` metadata we publish to PyPI, not against `uv.lock`. Three packages reachable through the `jupyter` extra now ship security patches that Renovate/Dependabot landed in `uv.lock` but did not lift in `pyproject.toml`. A consumer doing `pip install aignostics[jupyter]` (or `uvx --with aignostics[jupyter]`) can still resolve the older, vulnerable versions.

## Key property: no dependency was upgraded

Every new lower bound in this diff is `<=` the currently locked version. Verified programmatically:

| Package | New floor | Locked in `uv.lock` | Result |
| --- | --- | --- | --- |
| `jupyterlab` | `>=4.5.7` | `4.5.7` | OK (equal) |
| `notebook` | `>=7.5.6` | `7.5.6` | OK (equal) |
| `jupyter-server` | `>=2.18.0` | `2.18.1` | OK (locked > floor) |

`uv lock` after the bumps produced **no version changes** — only `requires-dist` specifier updates and the `extras` set in our own package's locked `dependencies` block. Behavioural regression risk equals a comment-only edit.

## What changed

**Runtime-optional (`[project.optional-dependencies].jupyter`)** — the `jupyter` extras block:

* `jupyterlab>=4.4.9` → `jupyterlab>=4.5.7` — adds:
  * [CVE-2026-40171](https://nvd.nist.gov/vuln/detail/CVE-2026-40171) / [GHSA-rch3-82jr-f9w9](https://github.com/advisories/GHSA-rch3-82jr-f9w9) — High (CVSS 8.4). Stored XSS via the JupyterLab CommandLinker / help extension. An attacker can craft a notebook that, on a single user click, steals authentication tokens and gains full account takeover via the Jupyter REST API (read/write all files, execute arbitrary code in kernels, open shell terminals).
  * [CVE-2026-42266](https://nvd.nist.gov/vuln/detail/CVE-2026-42266) / [GHSA-37w4-hwhx-4rc4](https://github.com/advisories/GHSA-37w4-hwhx-4rc4) — High (CVSS 8.8). Extension-allowlist enforcement bypass: an authenticated attacker can install malicious third-party extensions via crafted POST requests in multi-tenant or shared JupyterHub deployments.
  * [CVE-2026-42557](https://nvd.nist.gov/vuln/detail/CVE-2026-42557) / [GHSA-mqcg-5x36-vfcg](https://github.com/advisories/GHSA-mqcg-5x36-vfcg) — High (CVSS 8.6). Crafted HTML buttons in notebooks can execute arbitrary JupyterLab commands (file deletion, code execution) on a single click without the user submitting any code.
* New entry: `notebook>=7.5.6` — adds [CVE-2026-40171](https://nvd.nist.gov/vuln/detail/CVE-2026-40171) (High) and [CVE-2026-42557](https://nvd.nist.gov/vuln/detail/CVE-2026-42557) (High). The same CommandLinker/XSS pair also affects the `notebook` package; Dependabot opened [#614](https://github.com/aignostics/python-sdk/pull/614) to bump `uv.lock` but the closing of that PR left no follow-up to lift the floor.
* New entry: `jupyter-server>=2.18.0` — adds:
  * [CVE-2025-61669](https://nvd.nist.gov/vuln/detail/CVE-2025-61669) / [GHSA-qh7q-6qm3-653w](https://github.com/advisories/GHSA-qh7q-6qm3-653w) — Medium (CVSS 6.0). Open redirect via `?next=` URL parameter, useful for phishing.
  * [CVE-2026-35397](https://nvd.nist.gov/vuln/detail/CVE-2026-35397) / [GHSA-5789-5fc7-67v3](https://github.com/advisories/GHSA-5789-5fc7-67v3) — High (CVSS 7.1). Path-traversal escape from `root_dir` via incorrect `startswith()` check on sibling directories that share a name prefix.
  * [CVE-2026-40110](https://nvd.nist.gov/vuln/detail/CVE-2026-40110) / [GHSA-24qx-w28j-9m6p](https://github.com/advisories/GHSA-24qx-w28j-9m6p) — High (CVSS 7.6). CORS Origin-header bypass: `re.match` without an end anchor lets `http://trusted.example.com.evil.com/` impersonate `trusted.example.com`.
  * [CVE-2026-40934](https://nvd.nist.gov/vuln/detail/CVE-2026-40934) / [GHSA-5mrq-x3x5-8v8f](https://github.com/advisories/GHSA-5mrq-x3x5-8v8f) — Medium (CVSS 6.8). Authentication cookie persistence across password rotation: cookie secret is never automatically rotated, so previously captured cookies remain valid after the user changes password.

**Runtime-core / dev-only**: no changes.

## Accepted advisories: re-verified

* `noxfile.py` carries no `--ignore-vuln` entries today. Trivially passes re-verification (skill Step 1c).
* No advisories were added or removed from any acceptance list this run.

## 30-day bot-PR floor-sync sweep (skill Step 1d.1)

All other security-tagged Renovate/Dependabot PRs merged into `main` in the last 30 days (`lxml→6.1.0`, `pillow→12.2.0`, `pytest→9.0.3`, `uv→0.11.6`, `marimo→0.23.0`, `nicegui→3.11.0`, `nbconvert→7.17.1`, `python-multipart→0.0.26`, `cryptography→46.0.7`) are already reflected as matching lower bounds in `pyproject.toml`. No additional drift to close.

Non-security bot PRs in the same window (`packaging→26`, `pyarrow→23`, `fastparquet→2026.3.0`, `idc-index-data→23.10.1`, `python-dotenv→1.2.2`, `authlib→1.6.11`, `pandas` constraint move) were verified against pyproject.toml floors — all in sync.

## Docs + tooling

`SUPPLY_CHAIN_VULNERABILITIES.md` was deleted from `main` in commit `59506a28` (revert of #580) on 2026-05-06, after the previous run of this routine had drafted updates to it. This PR therefore does **not** touch that doc — the only canonical record of CVE protections is now the inline `# CVE-…` comments on each lower bound in `pyproject.toml`, which this PR keeps consistent: each affected line carries severity (`(High)`, `(Medium)`) and the fix-version per CVE.

No changes to `noxfile.py`, `.pre-commit-config.yaml`, or any tooling — the `[tool.uv]` `required-version` and `astral-sh/uv-pre-commit` rev are already in sync at `>=0.11.6`.

## Test plan

- [x] `make audit` green (zero advisories from `pip-audit`)
- [x] `make lint` green (ruff format, ruff check, pyright, mypy)
- [x] `make test_unit` — **see note below**: a pre-existing flake (32 failures in `tests/aignostics/platform/client_cache_test.py` and `client_me_retry_test.py`, all "Failed: Timeout (>10.0s) from pytest-timeout") reproduces identically on `main` without any of these changes. The flake is in tenacity-based retry logic interacting with the 10s `pytest-timeout`; it is unrelated to dependency floor changes.
- [x] Manual: every bound change verified to be a *raise or add* vs `main` — never a lower (`packaging.version.Version` comparison).
- [x] Manual: every new bound is `<=` the currently locked version (no upgrade).
- [x] Manual: skill Step 1d.2 doc-drift check — N/A (`SUPPLY_CHAIN_VULNERABILITIES.md` deleted on `main`).

## Out of scope

* The pre-existing `client_cache_test` / `client_me_retry_test` timeout flake — separate concern, will be flagged on the ticket.
* Closed Dependabot/Renovate PRs (`#614`, `#615`, `#628`) that originally proposed these bumps — they will be auto-superseded once this PR merges (their `uv.lock`-only changes are equivalent or older).

🤖 Generated by Claude Opus 4.7 (cloud routine `pysdk-audit-daily`) for [helmut@aignostics.com](mailto:helmut@aignostics.com).

[PYSDK-124]: https://aignx.atlassian.net/browse/PYSDK-124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ