### PR TITLE
fix(test): enable E2E pytest mark

### DIFF
--- a/tests/aignostics/application/cli_test.py
+++ b/tests/aignostics/application/cli_test.py
@@ -205,7 +205,7 @@ def test_cli_application_describe_not_found(runner: CliRunner, record_property) 
     assert "Application with ID 'unknown' not found." in normalize_output(result.output)
 
 
-# @pytest.mark.e2e
+@pytest.mark.e2e
 @pytest.mark.timeout(timeout=60)
 def test_cli_application_dump_schemata(runner: CliRunner, tmp_path: Path, record_property) -> None:
     """Check application dump schemata works as expected."""


### PR DESCRIPTION
This should not have been commented out in https://github.com/aignostics/python-sdk/pull/634.