### PR TITLE
fix(deps): update starlette to >=1.0.1 to fix PYSEC-2026-161

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,8 +133,7 @@ dependencies = [
     "urllib3>=2.5.0",                   # CVE-2025-50181, CVE-2025-50182
     "pillow>=12.2.0",                   # CVE-2025-48379 (>=11.3.0); CVE-2026-25990 (>=12.1.1, Renovate #428); CVE-2026-40192 (>=12.2.0, Renovate #539)
     "aiohttp>=3.13.4",                  # CVE-2025-53643, CVE-2025-69223..9 (>=3.13.3); CVE-2026-22815 (>=3.13.4, Renovate #527)
-    "starlette>=0.47.2",                # CVE-2025-54121
-    "starlette>=0.49.1",                # GHSA-7f5h-v6xp-fcq8
+    "starlette>=1.0.1",                 # CVE-2025-54121, GHSA-7f5h-v6xp-fcq8, PYSEC-2026-161
     "lxml>=6.1.0",                      # CVE-2026-41066 (Renovate #556); also required for python 3.14 pre-built wheels
     "filelock>=3.20.3",                 # CVE-2025-68146 (>=3.20.1); CVE-2026-22701 (>=3.20.3, Renovate #387)
     "marshmallow>=3.26.2",              # CVE-2025-68480

--- a/uv.lock
+++ b/uv.lock
@@ -237,8 +237,7 @@ requires-dist = [
     { name = "sentry-sdk", specifier = ">=2.47.0,<3" },
     { name = "shapely", specifier = ">=2.1.2,<3" },
     { name = "shapely", marker = "extra == 'marimo'", specifier = ">=2.1.0,<3" },
-    { name = "starlette", specifier = ">=0.47.2" },
-    { name = "starlette", specifier = ">=0.49.1" },
+    { name = "starlette", specifier = ">=1.0.1" },
     { name = "tenacity", specifier = ">=9.1.2,<10" },
     { name = "tornado", specifier = ">=6.5.5" },
     { name = "tqdm", specifier = ">=4.67.1,<5" },
@@ -7539,15 +7538,15 @@ wheels = [
 
 [[package]]
 name = "starlette"
-version = "1.0.0"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/66/4d20cdf39a8d6a51e663b7038e3b828ff211d3891a43a713fe7e4643f3a8/starlette-1.1.0.tar.gz", hash = "sha256:e83c7fe0ddecd8719c5b840080325aec0260acec86e9832899e377b91d65e90f", size = 2660060, upload-time = "2026-05-23T16:55:41.376Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+    { url = "https://files.pythonhosted.org/packages/93/79/920b8e0a8b20f793e8d64855095cb8febabf6175b8550b6f7a547d813891/starlette-1.1.0-py3-none-any.whl", hash = "sha256:7f0dfd38e428aad5cb6f9f667f0ca1d2d8ca3f3385dccac8305f79ec98458382", size = 72899, upload-time = "2026-05-23T16:55:39.201Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Consolidates separate starlette overrides into one entry covering CVE-2025-54121, GHSA-7f5h-v6xp-fcq8, and PYSEC-2026-161 (fixed in 1.0.1). Starlette resolves to 1.1.0 in the lockfile.