### PR TITLE
feat(ci): update publish pipeline for dual-package aignostics-sdk release [PYSDK-140]

### DIFF
--- a/.github/workflows/_package-publish.yml
+++ b/.github/workflows/_package-publish.yml
@@ -171,17 +171,36 @@ jobs:
           GIT_CLIFF_CHANGELOG: ${{ steps.git-cliff.outputs.changelog }}
         run: cat "$GIT_CLIFF_CHANGELOG"
 
-      - name: Build distribution into dist/
+      - name: Verify lockstep versioning
         shell: bash
-        run: make dist
+        run: |
+          SDK_VERSION=$(grep '^version = ' packages/aignostics-sdk/pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          FULL_VERSION=$(grep '^version = ' packages/aignostics/pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          if [ "$SDK_VERSION" != "$FULL_VERSION" ]; then
+            echo "❌ Version mismatch: aignostics-sdk=$SDK_VERSION, aignostics=$FULL_VERSION"
+            exit 1
+          fi
+          echo "✅ Versions match: $SDK_VERSION"
 
-      - name: Publish distribution to Python Package Index at pypi.org
+      - name: Build aignostics-sdk distribution
+        shell: bash
+        run: uv build --package aignostics-sdk --out-dir dist/
+
+      - name: Publish aignostics-sdk to PyPI
         shell: bash
         env:
           UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
-        run: |
-          # Use uv's credential storage - uv will read from UV_PUBLISH_TOKEN env var automatically
-          uv publish
+        run: uv publish dist/aignostics_sdk-*
+
+      - name: Build aignostics distribution
+        shell: bash
+        run: uv build --package aignostics --out-dir dist/
+
+      - name: Publish aignostics to PyPI
+        shell: bash
+        env:
+          UV_PUBLISH_TOKEN: ${{ secrets.UV_PUBLISH_TOKEN }}
+        run: uv publish dist/aignostics-*
 
       - name: Download test results for ubuntu-latest generated in _test.yml
         if: |
@@ -276,3 +295,25 @@ jobs:
           # See https://github.com/cli/cli/discussions/10696
           gh api repos/aignostics/python-sdk/dispatches \
             -f event_type=release_created_programatically
+
+  smoke_test_slim:
+    runs-on: ubuntu-latest
+    needs: package_publish
+    continue-on-error: true
+    steps:
+      - name: Install uv
+        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+
+      - name: Smoke test aignostics-sdk
+        shell: bash
+        run: |
+          VERSION=$(echo "${{ github.ref_name }}" | sed 's/^v//')
+          uv venv /tmp/slim-venv
+          uv pip install --python /tmp/slim-venv/bin/python "aignostics-sdk==$VERSION"
+          /tmp/slim-venv/bin/aignostics-sdk --help
+          /tmp/slim-venv/bin/python -c "from aignostics_sdk.platform import Client; print('✅ slim import OK')"
+          if /tmp/slim-venv/bin/python -c "import openslide" 2>/dev/null; then
+            echo "❌ openslide should not be installed in slim package"
+            exit 1
+          fi
+          echo "✅ Heavy deps correctly absent"

--- a/noxfile.py
+++ b/noxfile.py
@@ -1027,5 +1027,6 @@ def act(session: nox.Session) -> None:
 
 @nox.session()
 def dist(session: nox.Session) -> None:
-    """Build wheel and put in dist/."""
-    session.run("uv", "build", external=True)
+    """Build wheels for both packages into dist/."""
+    session.run("uv", "build", "--package", "aignostics-sdk", "--out-dir", "dist/", external=True)
+    session.run("uv", "build", "--package", "aignostics", "--out-dir", "dist/", external=True)


### PR DESCRIPTION
## Release Train — PYSDK-133

> Verify wiring on the integration branch first: **#661** (draft, targets `main`)

| Step | PR | Jira | Phase | Notes |
|------|----|------|-------|-------|
| 1 | #653 | PYSDK-134 | Workspace scaffolding | **Merge first — gates everything below** |
| 2a | #656 | PYSDK-135 | Source migration | After #653 |
| 2b | #655 | PYSDK-138 | Dependency split | After #653, parallel with 2a |
| 2c | #654 | PYSDK-139 | Tooling updates | After #653, parallel with 2a |
| 3 | #657 | PYSDK-136 | Import rewrite | After #656 |
| 4a | #658 | PYSDK-137 | Slim CLI | After #657 |
| 4b | #659 | PYSDK-141 | Tests | After #657, parallel with 4a |
| ∞ | #651 | PYSDK-140 | CI/CD pipeline | Independent — merge any time |
| ∞ | #652 | PYSDK-142 | Docs & migration | Independent — merge any time |

> **Retargeting**: each PR currently targets its predecessor branch. After the predecessor merges into `feat/PYSDK-133/python-sdk-slim`, retarget this PR to `feat/PYSDK-133/python-sdk-slim` before merging it.

---

> **This PR — Independent**: No dependency on the sequential chain. Can be merged any time into `feat/PYSDK-133/python-sdk-slim`.

## Summary

This PR updates the CI/CD publish pipeline to handle the new dual-package workspace structure introduced in PYSDK-133.

### Changes

- **Sequential dual-package publish**: Replaced the single `uv publish` step with a build-then-publish sequence for each package. `aignostics-sdk` is built and published first (required because `aignostics` depends on it), then `aignostics` is built and published second.

- **Lockstep version consistency check**: Added a pre-publish gate that reads the `version =` field from both `packages/aignostics-sdk/pyproject.toml` and `packages/aignostics/pyproject.toml` and fails fast if they differ. This enforces the lockstep versioning contract before anything reaches PyPI.

- **Slim package smoke test job**: Added a new `smoke_test_slim` job (marked `continue-on-error: true` so it does not gate the full package publish). After `package_publish` completes, this job installs `aignostics-sdk` from PyPI into a fresh venv, asserts `aignostics-sdk --help` exits 0, verifies `from aignostics_sdk.platform import Client` works, and confirms that heavy deps like `openslide` are absent.

- **GitHub release artifact coverage**: The existing `./dist/*` glob in both `gh release create` steps already covers both wheels since all builds write into `dist/`. No change needed here.

- **`make dist` / noxfile update**: Updated the `dist()` nox session to build both packages (`uv build --package aignostics-sdk --out-dir dist/` then `uv build --package aignostics --out-dir dist/`) so `make dist` stays consistent with the new publish flow.

> **Note**: The `Verify lockstep versioning` step reads from `packages/aignostics-sdk/pyproject.toml` and `packages/aignostics/pyproject.toml`, which will exist once the parent branch (`feat/PYSDK-133/python-sdk-slim`) lands. This PR is intentionally forward-looking and targets that branch.

## Test plan

- [ ] Verify YAML is syntactically valid (`python -c "import yaml; yaml.safe_load(open('.github/workflows/_package-publish.yml'))"`)
- [ ] Confirm `package_publish` job builds and publishes `aignostics-sdk` before `aignostics`
- [ ] Confirm `smoke_test_slim` job does not block the release on failure (`continue-on-error: true`)
- [ ] Confirm `make dist` builds both packages once the workspace packages exist