### PR TITLE
feat(packaging): introduce uv workspace structure for aignostics-sdk split [PYSDK-134]

### DIFF
--- a/packages/aignostics-sdk/pyproject.toml
+++ b/packages/aignostics-sdk/pyproject.toml
@@ -1,0 +1,181 @@
+[project]
+name = "aignostics-sdk"
+version = "1.4.0"
+description = "🔬 Python SDK providing access to the Aignostics Platform. Includes Aignostics Launchpad (Desktop Application), Aignostics CLI (Command-Line Interface), example notebooks, and Aignostics Client Library."
+readme = "../../README.md"
+authors = [
+    { name = "Helmut Hoffer von Ankershoffen", email = "helmut@aignostics.com" },
+    { name = "Andreas Kunft", email = "andreas@aignostics.com" },
+]
+license = { file = "../../LICENSE" }
+
+keywords = [
+    "aignostics",
+    "atlas",
+    "whole-slide-imaging",
+    "machine-learning",
+    "digital-pathology",
+    "medical-imaging",
+    "qupath",
+    "dicom",
+    "pydicom",
+    "openslide",
+    "image-data-commons",
+    "act",
+    "codecov",
+    "copier",
+    "cyclonedx",
+    "devcontainer",
+    "detect-secrets",
+    "docker",
+    "git-cliff",
+    "jupyter",
+    "marimo",
+    "mypy",
+    "nox",
+    "nicegui",
+    "oe-python-template",
+    "pip-audit",
+    "pip-licenses",
+    "pre-commit",
+    "pydantic",
+    "pytest",
+    "python",
+    "pypi",
+    "readthedocs",
+    "ruff",
+    "sonarqube",
+    "sonarcloud",
+    "sphinx",
+    "typer",
+    "uv",
+]
+
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: End Users/Desktop",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: Microsoft :: Windows",
+    "Framework :: Pydantic",
+    "Framework :: Pytest",
+    "Typing :: Typed",
+    "Natural Language :: English",
+]
+
+# WARNING: The upper bound of requires-python is *not* respected by uvx
+requires-python = ">=3.11, <3.15"
+
+dependencies = [
+    # From Template
+    "fastapi[all,standard]>=0.123.10",
+    "humanize>=4.14.0,<5",
+    "nicegui[native]>=3.11.0,<4",
+    "packaging>=26,<27",
+    "platformdirs>=4.5.1,<5",
+    "psutil>=7.1.3,<8",
+    "pydantic-settings>=2.12.0,<3",
+    "pywin32>=311,<312; sys_platform == 'win32'",
+    "pyyaml>=6.0.3,<7",
+    "sentry-sdk>=2.47.0,<3",
+    "typer>=0.20.0,<1",
+    # Custom
+    "boto3>=1.42.4,<2",
+    "certifi>=2025.11.12",
+    "defusedxml>=0.7.1",
+    "dicom-validator>=0.7.3,<1",
+    "dicomweb-client[gcp]>=0.59.3,<1",
+    "duckdb>=1.4.2,<=2",
+    "google-cloud-storage>=3.6.0,<4",
+    "crc32c>=2.8,<3",
+    "highdicom>=0.26.1,<1; python_version < '3.14'",
+    "html-sanitizer>=2.6.0,<3",
+    "httpx>=0.28.1,<1",
+    "idc-index-data==24.0.3",
+    "ijson>=3.4.0.post0,<4",
+    "jsf>=0.11.2,<1",
+    "jsonschema[format-nongpl]>=4.25.1,<5",
+    "loguru>=0.7.3,<1",
+    "openslide-bin>=4.0.0.10,<5",
+    "openslide-python>=1.4.3,<2",
+    "pandas>=2.3.3,<4",
+    "platformdirs>=4.3.2,<5",
+    "procrastinate>=3.5.3",
+    "fastparquet>=2026.3.0,<2026.4.0; python_version < '3.14'",
+    "pyarrow>=23.0.1,<24; python_version >= '3.14'",
+    "pyjwt[crypto]>=2.12.0,<3",
+    "python-dateutil>=2.9.0.post0,<3",
+    "requests>=2.33.0,<3",
+    "requests-oauthlib>=2.0.0,<3",
+    "s5cmd>=0.3.3,<1",
+    "semver>=3.0.4,<4",
+    "shapely>=2.1.2,<3",
+    "tenacity>=9.1.2,<10",
+    "tqdm>=4.67.1,<5",
+    "truststore>=0.10.4,<1",
+    "urllib3>=2.6.3,<3",
+    "wsidicom>=0.28.1,<1",
+    "fastmcp>=3.2.0,<4",
+    # Transitive overrides
+    "rfc3987; sys_platform == 'never'",
+    "h11>=0.16.0",
+    "tornado>=6.5.5",
+    "urllib3>=2.5.0",
+    "pillow>=12.2.0",
+    "aiohttp>=3.13.4",
+    "starlette>=1.0.1",
+    "lxml>=6.1.0",
+    "filelock>=3.20.3",
+    "marshmallow>=3.26.2",
+    "pygments>=2.20.0",
+    "cryptography>=46.0.7",
+    "pydicom>=3.0.2",
+    "pyasn1>=0.6.3",
+    "lxml-html-clean>=0.4.4",
+    "python-multipart>=0.0.26",
+    "protobuf>=6.33.5",
+]
+
+[project.optional-dependencies]
+pyinstaller = ["pyinstaller>=6.14.0,<7"]
+jupyter = [
+    "jupyter>=1.1.1,<2",
+    "jupyter-core>=5.8.1",
+    "jupyterlab>=4.4.9",
+    "nbconvert>=7.17.1",
+]
+marimo = [
+    "cloudpathlib>=0.23.0,<1",
+    "ipython>=9.8.0,<10",
+    "marimo>=0.23.0,<1",
+    "matplotlib>=3.10.7,<4",
+    "shapely>=2.1.0,<3",
+]
+qupath = []
+
+[project.scripts]
+aignostics-sdk = "aignostics_sdk.cli:cli"
+
+[build-system]
+requires = ["hatchling==1.29.0"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["src/*"]
+# TODO(Phase 5): Bundle codegen/out/aignx into wheel. Hatchling does not support
+# paths outside the project root (../../codegen/out/*). Options: symlink, copy
+# via a build hook, or use a hatch plugin. Deferred to the codegen migration phase.
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/aignostics_sdk"]
+
+[tool.hatch.metadata]
+allow-direct-references = true

--- a/packages/aignostics-sdk/src/aignostics_sdk/__init__.py
+++ b/packages/aignostics-sdk/src/aignostics_sdk/__init__.py
@@ -1,0 +1,1 @@
+"""Package stub — source migrated in Phase 2."""

--- a/packages/aignostics/pyproject.toml
+++ b/packages/aignostics/pyproject.toml
@@ -1,0 +1,123 @@
+[project]
+name = "aignostics"
+version = "1.4.0"
+description = "🔬 Python SDK providing access to the Aignostics Platform. Includes Aignostics Launchpad (Desktop Application), Aignostics CLI (Command-Line Interface), example notebooks, and Aignostics Client Library."
+readme = "../../README.md"
+authors = [
+    { name = "Helmut Hoffer von Ankershoffen", email = "helmut@aignostics.com" },
+    { name = "Andreas Kunft", email = "andreas@aignostics.com" },
+]
+license = { file = "../../LICENSE" }
+
+keywords = [
+    "aignostics",
+    "atlas",
+    "whole-slide-imaging",
+    "machine-learning",
+    "digital-pathology",
+    "medical-imaging",
+    "qupath",
+    "dicom",
+    "pydicom",
+    "openslide",
+    "image-data-commons",
+    "act",
+    "codecov",
+    "copier",
+    "cyclonedx",
+    "devcontainer",
+    "detect-secrets",
+    "docker",
+    "git-cliff",
+    "jupyter",
+    "marimo",
+    "mypy",
+    "nox",
+    "nicegui",
+    "oe-python-template",
+    "pip-audit",
+    "pip-licenses",
+    "pre-commit",
+    "pydantic",
+    "pytest",
+    "python",
+    "pypi",
+    "readthedocs",
+    "ruff",
+    "sonarqube",
+    "sonarcloud",
+    "sphinx",
+    "typer",
+    "uv",
+]
+
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Intended Audience :: End Users/Desktop",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: POSIX :: Linux",
+    "Operating System :: Microsoft :: Windows",
+    "Framework :: Pydantic",
+    "Framework :: Pytest",
+    "Typing :: Typed",
+    "Natural Language :: English",
+]
+
+# WARNING: The upper bound of requires-python is *not* respected by uvx
+requires-python = ">=3.11, <3.15"
+
+dependencies = [
+    "aignostics-sdk==1.4.0",
+    # Heavy deps will be moved here from aignostics-sdk in Phase 5
+]
+
+[project.optional-dependencies]
+pyinstaller = ["pyinstaller>=6.14.0,<7"]
+jupyter = [
+    "jupyter>=1.1.1,<2",
+    "jupyter-core>=5.8.1",
+    "jupyterlab>=4.4.9",
+    "nbconvert>=7.17.1",
+]
+marimo = [
+    "cloudpathlib>=0.23.0,<1",
+    "ipython>=9.8.0,<10",
+    "marimo>=0.23.0,<1",
+    "matplotlib>=3.10.7,<4",
+    "shapely>=2.1.0,<3",
+]
+qupath = []
+
+[project.scripts]
+aignostics = "aignostics.cli:cli"
+
+[project.urls]
+Homepage = "https://aignostics.readthedocs.io/en/latest/"
+Documentation = "https://aignostics.readthedocs.io/en/latest/"
+Source = "https://github.com/aignostics/python-sdk"
+Changelog = "https://github.com/aignostics/python-sdk/releases"
+Issues = "https://github.com/aignostics/python-sdk/issues"
+
+[build-system]
+requires = ["hatchling==1.29.0"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build]
+include = ["src/*"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/aignostics"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
+
+[tool.uv.sources]
+aignostics-sdk = { workspace = true }

--- a/packages/aignostics/src/aignostics/__init__.py
+++ b/packages/aignostics/src/aignostics/__init__.py
@@ -1,0 +1,1 @@
+"""Package stub — source migrated in Phase 2."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,169 +1,3 @@
-[project]
-name = "aignostics"
-version = "1.4.0"
-description = "🔬 Python SDK providing access to the Aignostics Platform. Includes Aignostics Launchpad (Desktop Application), Aignostics CLI (Command-Line Interface), example notebooks, and Aignostics Client Library."
-readme = "README.md"
-authors = [
-    { name = "Helmut Hoffer von Ankershoffen", email = "helmut@aignostics.com" },
-    { name = "Andreas Kunft", email = "andreas@aignostics.com" },
-]
-license = { file = "LICENSE" }
-
-keywords = [
-    "aignostics",
-    "atlas",
-    "whole-slide-imaging",
-    "machine-learning",
-    "digital-pathology",
-    "medical-imaging",
-    "qupath",
-    "dicom",
-    "pydicom",
-    "openslide",
-    "image-data-commons",
-    "act",
-    "codecov",
-    "copier",
-    "cyclonedx",
-    "devcontainer",
-    "detect-secrets",
-    "docker",
-    "git-cliff",
-    "jupyter",
-    "marimo",
-    "mypy",
-    "nox",
-    "nicegui",
-    "oe-python-template",
-    "pip-audit",
-    "pip-licenses",
-    "pre-commit",
-    "pydantic",
-    "pytest",
-    "python",
-    "pypi",
-    "readthedocs",
-    "ruff",
-    "sonarqube",
-    "sonarcloud",
-    "sphinx",
-    "typer",
-    "uv",
-]
-
-classifiers = [
-    "Development Status :: 3 - Alpha",
-    "Intended Audience :: Developers",
-    "Intended Audience :: End Users/Desktop",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
-    "Programming Language :: Python :: 3.14",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: MacOS :: MacOS X",
-    "Operating System :: POSIX :: Linux",
-    "Operating System :: Microsoft :: Windows",
-    "Framework :: Pydantic",
-    "Framework :: Pytest",
-    "Typing :: Typed",
-    "Natural Language :: English",
-]
-
-# WARNING: The upper bound of requires-python is *not* respected by uvx
-requires-python = ">=3.11, <3.15"
-
-dependencies = [
-    # From Template
-    "fastapi[all,standard]>=0.123.10",
-    "humanize>=4.14.0,<5",
-    "nicegui[native]>=3.11.0,<4",  # CVE-2026-21871, CVE-2026-21873, CVE-2026-21874 (>=3.5.0); CVE-2026-25516 (>=3.7.0, #418); CVE-2026-27156 (>=3.8.0, #448); CVE-2026-33332 (>=3.9.0, #498); CVE-2026-39844 (>=3.10.0, #531). 3.11.0 fixes async event handler exception leaks and refines ValueChangeEventArguments generics.
-    "packaging>=26,<27",
-    "platformdirs>=4.5.1,<5",
-    "psutil>=7.1.3,<8",
-    "pydantic-settings>=2.12.0,<3",
-    "pywin32>=311,<312; sys_platform == 'win32'",
-    "pyyaml>=6.0.3,<7",
-    "sentry-sdk>=2.47.0,<3",
-    "typer>=0.20.0,<1",
-    # Custom
-    "boto3>=1.42.4,<2",
-    "certifi>=2025.11.12",
-    "defusedxml>=0.7.1",
-    "dicom-validator>=0.7.3,<1",
-    "dicomweb-client[gcp]>=0.59.3,<1",
-    "duckdb>=1.4.2,<=2",
-    "google-cloud-storage>=3.6.0,<4",
-    "crc32c>=2.8,<3", # TODO(Helmut): Remove and back to google_crc32c when that supports Python 3.14
-    "highdicom>=0.26.1,<1; python_version < '3.14'", # transitive dependency pyjpegls not yet supporting Python 3.14
-    "html-sanitizer>=2.6.0,<3",
-    "httpx>=0.28.1,<1",
-    "idc-index-data==24.0.3",
-    "ijson>=3.4.0.post0,<4",
-    "jsf>=0.11.2,<1",
-    "jsonschema[format-nongpl]>=4.25.1,<5",
-    "loguru>=0.7.3,<1",
-    "openslide-bin>=4.0.0.10,<5",
-    "openslide-python>=1.4.3,<2",
-    "pandas>=2.3.3,<4",
-    "platformdirs>=4.3.2,<5",
-    "procrastinate>=3.5.3",
-    "fastparquet>=2026.3.0,<2026.4.0; python_version < '3.14'",
-    "pyarrow>=23.0.1,<24; python_version >= '3.14'",
-    "pyjwt[crypto]>=2.12.0,<3", # CVE-2026-32597 requires >=2.12.0 (Renovate #475)
-    "python-dateutil>=2.9.0.post0,<3",
-    # "pywebview[qt6]>=5.4,<6; sys_platform == 'linux'",
-    "requests>=2.33.0,<3", # CVE-2026-25645 requires >= 2.33.0
-    "requests-oauthlib>=2.0.0,<3",
-    "s5cmd>=0.3.3,<1",
-    "semver>=3.0.4,<4",
-    "shapely>=2.1.2,<3",
-    "tenacity>=9.1.2,<10",
-    "tqdm>=4.67.1,<5",
-    "truststore>=0.10.4,<1",
-    "urllib3>=2.6.3,<3", # CVE-2026-21441 requires >= 2.6.3
-    "wsidicom>=0.28.1,<1",
-    "fastmcp>=3.2.0,<4",
-    # Transitive overrides: lower bounds enforced to shield consumers from known CVEs/GHSAs.
-    # WARNING: one cannot negate or downgrade a dependency required here. use override-dependencies for that.
-    "rfc3987; sys_platform == 'never'", # GPLv3
-    "h11>=0.16.0",                      # CVE-2025-43859
-    "tornado>=6.5.5",                   # CVE-2025-47287 (>=6.5.0); GHSA-78cv-mqj4-43f7 (>=6.5.5, Renovate #472)
-    "urllib3>=2.5.0",                   # CVE-2025-50181, CVE-2025-50182
-    "pillow>=12.2.0",                   # CVE-2025-48379 (>=11.3.0); CVE-2026-25990 (>=12.1.1, Renovate #428); CVE-2026-40192 (>=12.2.0, Renovate #539)
-    "aiohttp>=3.13.4",                  # CVE-2025-53643, CVE-2025-69223..9 (>=3.13.3); CVE-2026-22815 (>=3.13.4, Renovate #527)
-    "starlette>=1.0.1",                 # CVE-2025-54121, GHSA-7f5h-v6xp-fcq8, PYSEC-2026-161
-    "lxml>=6.1.0",                      # CVE-2026-41066 (Renovate #556); also required for python 3.14 pre-built wheels
-    "filelock>=3.20.3",                 # CVE-2025-68146 (>=3.20.1); CVE-2026-22701 (>=3.20.3, Renovate #387)
-    "marshmallow>=3.26.2",              # CVE-2025-68480
-    "pygments>=2.20.0",                 # CVE-2026-4539 (>=2.20.0); transitive via rich
-    "cryptography>=46.0.7",             # CVE-2026-39892 (>=46.0.7); transitive via pyjwt[crypto]
-    "pydicom>=3.0.2",                   # CVE-2026-32711 (>=3.0.2); transitive via dicomweb-client/wsidicom/highdicom
-    "pyasn1>=0.6.3",                    # CVE-2026-30922 (>=0.6.3); transitive via cryptography
-    "lxml-html-clean>=0.4.4",           # CVE-2026-28348, CVE-2026-28350 (>=0.4.4); transitive via html-sanitizer
-    "python-multipart>=0.0.26",         # CVE-2026-24486 (>=0.0.22), CVE-2026-40347 (>=0.0.26); transitive via fastapi/starlette
-    "protobuf>=6.33.5",                 # CVE-2026-0994 (>=6.33.5); transitive via google-cloud-storage/sentry-sdk
-]
-
-[project.optional-dependencies]
-pyinstaller = ["pyinstaller>=6.14.0,<7"]
-jupyter = [
-    "jupyter>=1.1.1,<2",
-    # Transitive overrides
-    # WARNING: one cannot negate or downgrade a dependency required here. use override-dependencies for that.
-    "jupyter-core>=5.8.1",              # CVE-2025-30167
-    "jupyterlab>=4.4.9",                # CVE-2025-59842
-    "nbconvert>=7.17.1",                # CVE-2025-53000 (>=7.17.0, Dependabot #424); CVE-2026-39377, CVE-2026-39378 (>=7.17.1, Dependabot #553)
-]
-marimo = [
-    "cloudpathlib>=0.23.0,<1",
-    "ipython>=9.8.0,<10",
-    "marimo>=0.23.0,<1", # GHSA-2679-6mx9-h9xc (Renovate #533)
-    "matplotlib>=3.10.7,<4",
-    "shapely>=2.1.0,<3",
-]
-qupath = []
 [dependency-groups]
 dev = [
     "autodoc-pydantic>=2.2.0,<3",
@@ -231,28 +65,8 @@ override-dependencies = [ # https://github.com/astral-sh/uv/issues/4422
 [tool.uv.sources]
 # No additional sources outside of src/ yet
 
-[project.scripts]
-aignostics = "aignostics.cli:cli"
-
-[project.urls]
-Homepage = "https://aignostics.readthedocs.io/en/latest/"
-Documentation = "https://aignostics.readthedocs.io/en/latest/"
-Source = "https://github.com/aignostics/python-sdk"
-Changelog = "https://github.com/aignostics/python-sdk/releases"
-Issues = "https://github.com/aignostics/python-sdk/issues"
-
-[build-system]
-requires = ["hatchling==1.29.0"]
-build-backend = "hatchling.build"
-
-[tool.hatch.build]
-include = ["src/*", "codegen/out/*", "examples"]
-
-[tool.hatch.build.targets.wheel]
-packages = ["src/aignostics", "codegen/out/aignx", "examples"]
-
-[tool.hatch.metadata]
-allow-direct-references = true
+[tool.uv.workspace]
+members = ["packages/*"]
 
 [tool.ruff]
 target-version = "py311"
@@ -434,15 +248,26 @@ pre_commit_hooks = [
 post_commit_hooks = []
 
 [[tool.bumpversion.files]]
-filename = "pyproject.toml"
+filename = "packages/aignostics-sdk/pyproject.toml"
+search = """
+[project]
+name = \"aignostics-sdk\"
+version = \"{current_version}\"\""""
+replace = """
+[project]
+name = \"aignostics-sdk\"
+version = \"{new_version}\"\""""
+
+[[tool.bumpversion.files]]
+filename = "packages/aignostics/pyproject.toml"
 search = """
 [project]
 name = \"aignostics\"
-version = \"{current_version}\""""
+version = \"{current_version}\"\""""
 replace = """
 [project]
 name = \"aignostics\"
-version = \"{new_version}\""""
+version = \"{new_version}\"\""""
 
 [[tool.bumpversion.files]]
 filename = "VERSION"

--- a/uv.lock
+++ b/uv.lock
@@ -14,7 +14,66 @@ resolution-markers = [
 ]
 
 [manifest]
+members = [
+    "aignostics",
+    "aignostics-sdk",
+]
 overrides = [{ name = "pytest", specifier = ">=9.0.1" }]
+
+[manifest.dependency-groups]
+dev = [
+    { name = "autodoc-pydantic", specifier = ">=2.2.0,<3" },
+    { name = "bump-my-version", specifier = ">=1.2.4,<2" },
+    { name = "coverage", specifier = ">=7.12.0,<7.13" },
+    { name = "cyclonedx-py", specifier = ">=1.0.1,<2" },
+    { name = "detect-secrets", specifier = ">=1.5.0,<2" },
+    { name = "enum-tools", specifier = ">=0.13.0,<1" },
+    { name = "fonttools", specifier = ">=4.60.2" },
+    { name = "furo", specifier = ">=2025.9.25" },
+    { name = "git-cliff", specifier = ">=2.10.1,<3" },
+    { name = "linkify-it-py", specifier = ">=2.0.3,<3" },
+    { name = "mypy", specifier = ">=1.19.0,<2" },
+    { name = "myst-parser", specifier = ">=5,<6" },
+    { name = "nox", extras = ["uv"], specifier = ">=2025.11.12" },
+    { name = "pip", specifier = ">=26.1" },
+    { name = "pip-audit", specifier = ">=2.10.0,<3" },
+    { name = "pip-licenses", git = "https://github.com/neXenio/pip-licenses.git?rev=master" },
+    { name = "pre-commit", specifier = ">=4.5.0,<5" },
+    { name = "pyright", specifier = ">=1.1.408,<1.1.409" },
+    { name = "pytest", specifier = ">=9.0.3,<10" },
+    { name = "pytest-asyncio", specifier = ">=1.3.0,<2" },
+    { name = "pytest-cov", specifier = ">=7.0.0,<8" },
+    { name = "pytest-docker", specifier = ">=3.2.5,<4" },
+    { name = "pytest-durations", specifier = ">=1.6.1,<2" },
+    { name = "pytest-env", specifier = ">=1.2.0,<2" },
+    { name = "pytest-md-report", specifier = ">=0.7.0,<1" },
+    { name = "pytest-regressions", specifier = ">=2.8.3,<3" },
+    { name = "pytest-retry", specifier = ">=1.7.0,<2" },
+    { name = "pytest-selenium", specifier = ">=4.1.0,<5" },
+    { name = "pytest-subprocess", specifier = ">=1.5.3,<2" },
+    { name = "pytest-timeout", specifier = ">=2.4.0,<3" },
+    { name = "pytest-watcher", specifier = ">=0.4.3,<1" },
+    { name = "pytest-xdist", extras = ["psutil"], specifier = ">=3.8.0,<4" },
+    { name = "ruff", specifier = ">=0.14.8,<1" },
+    { name = "scalene", specifier = ">=2.0.1,<3" },
+    { name = "sphinx", specifier = ">=8.2.3,<9" },
+    { name = "sphinx-autobuild", specifier = ">=2025.8.25,<2026" },
+    { name = "sphinx-click", specifier = ">=6.2.0,<7" },
+    { name = "sphinx-copybutton", specifier = ">=0.5.2,<1" },
+    { name = "sphinx-inline-tabs", specifier = ">=2025.12.21,<2026" },
+    { name = "sphinx-rtd-theme", specifier = ">=3.0.2,<4" },
+    { name = "sphinx-selective-exclude", specifier = ">=1.0.3,<2" },
+    { name = "sphinx-toolbox", specifier = ">=4.1.0,<5" },
+    { name = "sphinxcontrib-mermaid" },
+    { name = "sphinxext-opengraph", specifier = ">=0.9.1,<1" },
+    { name = "swagger-plugin-for-sphinx", specifier = ">=7,<8" },
+    { name = "tomli", specifier = ">=2.3.0,<3" },
+    { name = "types-pyyaml", specifier = ">=6.0.12.20250915,<7" },
+    { name = "types-requests", specifier = ">=2.32.4.20250913,<3" },
+    { name = "uv", specifier = ">=0.11.6" },
+    { name = "virtualenv", specifier = ">=20.36.1" },
+    { name = "watchdog", specifier = ">=6.0.0,<7" },
+]
 
 [[package]]
 name = "accessible-pygments"
@@ -31,7 +90,49 @@ wheels = [
 [[package]]
 name = "aignostics"
 version = "1.4.0"
-source = { editable = "." }
+source = { editable = "packages/aignostics" }
+dependencies = [
+    { name = "aignostics-sdk" },
+]
+
+[package.optional-dependencies]
+jupyter = [
+    { name = "jupyter" },
+    { name = "jupyter-core" },
+    { name = "jupyterlab" },
+    { name = "nbconvert" },
+]
+marimo = [
+    { name = "cloudpathlib" },
+    { name = "ipython" },
+    { name = "marimo" },
+    { name = "matplotlib" },
+    { name = "shapely" },
+]
+pyinstaller = [
+    { name = "pyinstaller" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aignostics-sdk", editable = "packages/aignostics-sdk" },
+    { name = "cloudpathlib", marker = "extra == 'marimo'", specifier = ">=0.23.0,<1" },
+    { name = "ipython", marker = "extra == 'marimo'", specifier = ">=9.8.0,<10" },
+    { name = "jupyter", marker = "extra == 'jupyter'", specifier = ">=1.1.1,<2" },
+    { name = "jupyter-core", marker = "extra == 'jupyter'", specifier = ">=5.8.1" },
+    { name = "jupyterlab", marker = "extra == 'jupyter'", specifier = ">=4.4.9" },
+    { name = "marimo", marker = "extra == 'marimo'", specifier = ">=0.23.0,<1" },
+    { name = "matplotlib", marker = "extra == 'marimo'", specifier = ">=3.10.7,<4" },
+    { name = "nbconvert", marker = "extra == 'jupyter'", specifier = ">=7.17.1" },
+    { name = "pyinstaller", marker = "extra == 'pyinstaller'", specifier = ">=6.14.0,<7" },
+    { name = "shapely", marker = "extra == 'marimo'", specifier = ">=2.1.0,<3" },
+]
+provides-extras = ["pyinstaller", "jupyter", "marimo", "qupath"]
+
+[[package]]
+name = "aignostics-sdk"
+version = "1.4.0"
+source = { editable = "packages/aignostics-sdk" }
 dependencies = [
     { name = "aiohttp" },
     { name = "boto3" },
@@ -115,61 +216,6 @@ pyinstaller = [
     { name = "pyinstaller" },
 ]
 
-[package.dev-dependencies]
-dev = [
-    { name = "autodoc-pydantic" },
-    { name = "bump-my-version" },
-    { name = "coverage" },
-    { name = "cyclonedx-py" },
-    { name = "detect-secrets" },
-    { name = "enum-tools" },
-    { name = "fonttools" },
-    { name = "furo" },
-    { name = "git-cliff" },
-    { name = "linkify-it-py" },
-    { name = "mypy" },
-    { name = "myst-parser" },
-    { name = "nox", extra = ["uv"] },
-    { name = "pip" },
-    { name = "pip-audit" },
-    { name = "pip-licenses" },
-    { name = "pre-commit" },
-    { name = "pyright" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "pytest-docker" },
-    { name = "pytest-durations" },
-    { name = "pytest-env" },
-    { name = "pytest-md-report" },
-    { name = "pytest-regressions" },
-    { name = "pytest-retry" },
-    { name = "pytest-selenium" },
-    { name = "pytest-subprocess" },
-    { name = "pytest-timeout" },
-    { name = "pytest-watcher" },
-    { name = "pytest-xdist", extra = ["psutil"] },
-    { name = "ruff" },
-    { name = "scalene" },
-    { name = "sphinx" },
-    { name = "sphinx-autobuild" },
-    { name = "sphinx-click" },
-    { name = "sphinx-copybutton" },
-    { name = "sphinx-inline-tabs" },
-    { name = "sphinx-rtd-theme" },
-    { name = "sphinx-selective-exclude" },
-    { name = "sphinx-toolbox" },
-    { name = "sphinxcontrib-mermaid" },
-    { name = "sphinxext-opengraph" },
-    { name = "swagger-plugin-for-sphinx" },
-    { name = "tomli" },
-    { name = "types-pyyaml" },
-    { name = "types-requests" },
-    { name = "uv" },
-    { name = "virtualenv" },
-    { name = "watchdog" },
-]
-
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.4" },
@@ -248,61 +294,6 @@ requires-dist = [
     { name = "wsidicom", specifier = ">=0.28.1,<1" },
 ]
 provides-extras = ["pyinstaller", "jupyter", "marimo", "qupath"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "autodoc-pydantic", specifier = ">=2.2.0,<3" },
-    { name = "bump-my-version", specifier = ">=1.2.4,<2" },
-    { name = "coverage", specifier = ">=7.12.0,<7.13" },
-    { name = "cyclonedx-py", specifier = ">=1.0.1,<2" },
-    { name = "detect-secrets", specifier = ">=1.5.0,<2" },
-    { name = "enum-tools", specifier = ">=0.13.0,<1" },
-    { name = "fonttools", specifier = ">=4.60.2" },
-    { name = "furo", specifier = ">=2025.9.25" },
-    { name = "git-cliff", specifier = ">=2.10.1,<3" },
-    { name = "linkify-it-py", specifier = ">=2.0.3,<3" },
-    { name = "mypy", specifier = ">=1.19.0,<2" },
-    { name = "myst-parser", specifier = ">=5,<6" },
-    { name = "nox", extras = ["uv"], specifier = ">=2025.11.12" },
-    { name = "pip", specifier = ">=26.1" },
-    { name = "pip-audit", specifier = ">=2.10.0,<3" },
-    { name = "pip-licenses", git = "https://github.com/neXenio/pip-licenses.git?rev=master" },
-    { name = "pre-commit", specifier = ">=4.5.0,<5" },
-    { name = "pyright", specifier = ">=1.1.408,<1.1.409" },
-    { name = "pytest", specifier = ">=9.0.3,<10" },
-    { name = "pytest-asyncio", specifier = ">=1.3.0,<2" },
-    { name = "pytest-cov", specifier = ">=7.0.0,<8" },
-    { name = "pytest-docker", specifier = ">=3.2.5,<4" },
-    { name = "pytest-durations", specifier = ">=1.6.1,<2" },
-    { name = "pytest-env", specifier = ">=1.2.0,<2" },
-    { name = "pytest-md-report", specifier = ">=0.7.0,<1" },
-    { name = "pytest-regressions", specifier = ">=2.8.3,<3" },
-    { name = "pytest-retry", specifier = ">=1.7.0,<2" },
-    { name = "pytest-selenium", specifier = ">=4.1.0,<5" },
-    { name = "pytest-subprocess", specifier = ">=1.5.3,<2" },
-    { name = "pytest-timeout", specifier = ">=2.4.0,<3" },
-    { name = "pytest-watcher", specifier = ">=0.4.3,<1" },
-    { name = "pytest-xdist", extras = ["psutil"], specifier = ">=3.8.0,<4" },
-    { name = "ruff", specifier = ">=0.14.8,<1" },
-    { name = "scalene", specifier = ">=2.0.1,<3" },
-    { name = "sphinx", specifier = ">=8.2.3,<9" },
-    { name = "sphinx-autobuild", specifier = ">=2025.8.25,<2026" },
-    { name = "sphinx-click", specifier = ">=6.2.0,<7" },
-    { name = "sphinx-copybutton", specifier = ">=0.5.2,<1" },
-    { name = "sphinx-inline-tabs", specifier = ">=2025.12.21,<2026" },
-    { name = "sphinx-rtd-theme", specifier = ">=3.0.2,<4" },
-    { name = "sphinx-selective-exclude", specifier = ">=1.0.3,<2" },
-    { name = "sphinx-toolbox", specifier = ">=4.1.0,<5" },
-    { name = "sphinxcontrib-mermaid" },
-    { name = "sphinxext-opengraph", specifier = ">=0.9.1,<1" },
-    { name = "swagger-plugin-for-sphinx", specifier = ">=7,<8" },
-    { name = "tomli", specifier = ">=2.3.0,<3" },
-    { name = "types-pyyaml", specifier = ">=6.0.12.20250915,<7" },
-    { name = "types-requests", specifier = ">=2.32.4.20250913,<3" },
-    { name = "uv", specifier = ">=0.11.6" },
-    { name = "virtualenv", specifier = ">=20.36.1" },
-    { name = "watchdog", specifier = ">=6.0.0,<7" },
-]
 
 [[package]]
 name = "aiofile"


### PR DESCRIPTION
## Release Train — PYSDK-133

> Verify wiring on the integration branch first: **#661** (draft, targets `main`)

| Step | PR | Jira | Phase | Notes |
|------|----|------|-------|-------|
| 1 | #653 | PYSDK-134 | Workspace scaffolding | **Merge first — gates everything below** |
| 2a | #656 | PYSDK-135 | Source migration | After #653 |
| 2b | #655 | PYSDK-138 | Dependency split | After #653, parallel with 2a |
| 2c | #654 | PYSDK-139 | Tooling updates | After #653, parallel with 2a |
| 3 | #657 | PYSDK-136 | Import rewrite | After #656 |
| 4a | #658 | PYSDK-137 | Slim CLI | After #657 |
| 4b | #659 | PYSDK-141 | Tests | After #657, parallel with 4a |
| ∞ | #651 | PYSDK-140 | CI/CD pipeline | Independent — merge any time |
| ∞ | #652 | PYSDK-142 | Docs & migration | Independent — merge any time |

> **Retargeting**: each PR currently targets its predecessor branch. After the predecessor merges into `feat/PYSDK-133/python-sdk-slim`, retarget this PR to `feat/PYSDK-133/python-sdk-slim` before merging it.

---

> **This PR — Step 1**: Must merge before anything else. All of steps 2a–4b depend on this.

## Summary

- Transforms root `pyproject.toml` into a workspace-only config: strips `[project]`, `[project.optional-dependencies]`, `[project.scripts]`, `[project.urls]`, `[build-system]`, and `[tool.hatch.*]`; adds `[tool.uv.workspace] members = ["packages/*"]`
- Creates `packages/aignostics-sdk/pyproject.toml` — the slim package, with full dependency list copied from the original root (dependency split is Phase 5); hatchling build config points to `src/aignostics_sdk`
- Creates `packages/aignostics/pyproject.toml` — the full meta-package depending on `aignostics-sdk==1.4.0` via `[tool.uv.sources]` workspace reference
- Creates minimal stub `__init__.py` files at `packages/aignostics-sdk/src/aignostics_sdk/__init__.py` and `packages/aignostics/src/aignostics/__init__.py`
- Updates `[tool.bumpversion.files]` to target the two new package `pyproject.toml` files instead of the root
- Regenerates `uv.lock` to include both workspace members

## Notes

- `uv sync --all-extras` resolves and installs both `aignostics==1.4.0` and `aignostics-sdk==1.4.0` from the workspace
- `make lint` fails with pre-existing `aignx.codegen` import errors — these are expected for Phase 1 since the `codegen/out/aignx` package isn't installed in the workspace venv yet; import rewrites happen in Phase 3
- Hatchling does not support `../../`-relative paths for `[tool.hatch.build.targets.wheel].packages`; the codegen bundling spec (`../../codegen/out/aignx`) has been deferred to Phase 5 with a TODO comment; this does not affect `uv sync` or workspace resolution
- Source migration (moving `src/aignostics/*` into the appropriate package `src/`) follows in PYSDK-135

## Test plan

- [ ] `uv sync --all-extras` completes successfully with both packages installed from the workspace
- [ ] `packages/aignostics-sdk/pyproject.toml` has `version = "1.4.0"`
- [ ] `packages/aignostics/pyproject.toml` has `version = "1.4.0"` and `depends on aignostics-sdk==1.4.0`
- [ ] Root `pyproject.toml` has no `[project]` section and includes `[tool.uv.workspace]`