### PR TITLE
chore(tooling): update dev tooling paths for uv workspace layout [PYSDK-139]

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -125,7 +125,7 @@ def lint(session: nox.Session) -> None:
         ".",
     )
     session.run("pyright", "--pythonversion", PYTHON_VERSION, "--threads")
-    session.run("mypy", "src")
+    session.run("mypy", "packages/aignostics-sdk/src", "packages/aignostics/src")
 
 
 @nox.session(python=[PYTHON_VERSION])
@@ -596,6 +596,7 @@ def _generate_pdf_docs(session: nox.Session) -> None:
         version_match = re.search(r"Version (\d+\.\d+\w*)", str(out))
         if not version_match:
             session.error("Could not determine latexmk version")
+        assert version_match is not None  # noqa: S101
 
         version_str = version_match.group(1)
 
@@ -603,6 +604,7 @@ def _generate_pdf_docs(session: nox.Session) -> None:
         match = re.match(r"(\d+\.\d+)", version_str)
         if not match:
             session.error(f"Could not parse version number from '{version_str}'")
+        assert match is not None  # noqa: S101
         base_version = match.group(1)
 
         if float(base_version) < LATEXMK_VERSION_MIN:
@@ -665,6 +667,7 @@ def docs_pdf(session: nox.Session) -> None:
         version_match = re.search(r"Version (\d+\.\d+\w*)", str(out))
         if not version_match:
             session.error("Could not determine latexmk version")
+        assert version_match is not None  # noqa: S101
 
         version_str = version_match.group(1)
 
@@ -672,6 +675,7 @@ def docs_pdf(session: nox.Session) -> None:
         match = re.match(r"(\d+\.\d+)", version_str)
         if not match:
             session.error(f"Could not parse version number from '{version_str}'")
+        assert match is not None  # noqa: S101
         base_version = match.group(1)
 
         if float(base_version) < LATEXMK_VERSION_MIN:
@@ -1028,4 +1032,5 @@ def act(session: nox.Session) -> None:
 @nox.session()
 def dist(session: nox.Session) -> None:
     """Build wheel and put in dist/."""
-    session.run("uv", "build", external=True)
+    session.run("uv", "build", "--package", "aignostics-sdk", "--out-dir", "dist/", external=True)
+    session.run("uv", "build", "--package", "aignostics", "--out-dir", "dist/", external=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,7 +147,13 @@ docstring-code-format = true
 convention = "google"
 
 [tool.mypy] # https://mypy.readthedocs.io/en/latest/config_file.html
-exclude = ["src/aignostics/third_party", "_notebook.py", "_pydicom_handler.py"]
+exclude = [
+    "packages/aignostics-sdk/src/aignostics_sdk/third_party",
+    "packages/aignostics/src/aignostics/third_party",
+    "packages/aignostics/src/aignostics/notebook/_notebook.py",
+    "packages/aignostics/src/aignostics/wsi/_pydicom_handler.py",
+    "packages/aignostics/src/aignostics/wsi/_openslide_handler.py",
+]
 junit_xml = "reports/mypy_junit.xml"
 plugins = "pydantic.mypy"
 strict = true
@@ -170,7 +176,7 @@ warn_untyped_fields = true
 main_file = "tests/main.py"
 testpaths = ["tests"]
 python_files = ["*_test.py", "test_*.py"]
-addopts = "-p nicegui.testing.plugin -v --strict-markers --log-disable=aignostics --cov=aignostics --cov-report=term-missing --cov-report=xml:reports/coverage.xml --cov-report=html:reports/coverage_html"
+addopts = "-p nicegui.testing.plugin -v --strict-markers --log-disable=aignostics --cov=aignostics_sdk --cov=aignostics --cov-report=term-missing --cov-report=xml:reports/coverage.xml --cov-report=html:reports/coverage_html"
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
 timeout = 10 # We use a rather short default timeout. Override with @pytest.mark.timeout(timeout=N)
@@ -207,20 +213,27 @@ md_report_exclude_outcomes = ["passed", "skipped"]
 [tool.coverage.run]
 sigterm = true
 relative_files = true
-source = ["src"]
+source = [
+    "packages/aignostics-sdk/src",
+    "packages/aignostics/src",
+]
 omit = [
-    "src/aignostics/aignostics.py",
-    "src/aignostics/third_party/*",
-    "src/aignostics/notebook/_notebook.py",
-    "src/aignostics/wsi/_pydicom_handler.py",
-    "src/aignostics/wsi/_openslide_handler.py",
+    "*/aignostics/aignostics.py",
+    "*/aignostics/third_party/*",
+    "*/aignostics_sdk/third_party/*",
+    "*/aignostics/notebook/_notebook.py",
+    "*/aignostics/wsi/_pydicom_handler.py",
+    "*/aignostics/wsi/_openslide_handler.py",
 ]
 branch = true
 parallel = true
 concurrency = ["thread", "multiprocessing"]
 
 [tool.coverage.paths]
-source = ["src/"]
+source = [
+    "packages/aignostics-sdk/src",
+    "packages/aignostics/src",
+]
 
 
 [tool.bumpversion]

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,5 +1,10 @@
 {
     "typeCheckingMode": "basic",
+    "include": [
+        "packages/aignostics-sdk/src",
+        "packages/aignostics/src",
+        "noxfile.py"
+    ],
     "exclude": [
         "**/.nox/**",
         "**/.venv/**",
@@ -7,7 +12,7 @@
         "**/dist-packages/**",
         "**/dist_vercel/.vercel/**",
         "**/dist_native/**",
-        "**/site-packages/**",
+        "**/site-packages/**"
     ],
     "ignore": [
         "**/third_party/**",
@@ -17,10 +22,10 @@
         "template/**",
         "tests/**",
         "codegen/**",
-        "src/aignostics/wsi/_pydicom_handler.py",
-        "src/aignostics/notebook/_notebook.py",
+        "packages/aignostics/src/aignostics/wsi/_pydicom_handler.py",
+        "packages/aignostics/src/aignostics/notebook/_notebook.py"
     ],
     "extraPaths": [
-        "./src/aignostics/utils/_"
+        "./packages/aignostics/src/aignostics/utils"
     ]
 }


### PR DESCRIPTION
## Release Train — PYSDK-133

> Verify wiring on the integration branch first: **#661** (draft, targets `main`)

| Step | PR | Jira | Phase | Notes |
|------|----|------|-------|-------|
| 1 | #653 | PYSDK-134 | Workspace scaffolding | **Merge first — gates everything below** |
| 2a | #656 | PYSDK-135 | Source migration | After #653 |
| 2b | #655 | PYSDK-138 | Dependency split | After #653, parallel with 2a |
| 2c | #654 | PYSDK-139 | Tooling updates | After #653, parallel with 2a |
| 3 | #657 | PYSDK-136 | Import rewrite | After #656 |
| 4a | #658 | PYSDK-137 | Slim CLI | After #657 |
| 4b | #659 | PYSDK-141 | Tests | After #657, parallel with 4a |
| ∞ | #651 | PYSDK-140 | CI/CD pipeline | Independent — merge any time |
| ∞ | #652 | PYSDK-142 | Docs & migration | Independent — merge any time |

> **Retargeting**: each PR currently targets its predecessor branch. After the predecessor merges into `feat/PYSDK-133/python-sdk-slim`, retarget this PR to `feat/PYSDK-133/python-sdk-slim` before merging it.

---

> **This PR — Step 2c**: Merge after #653 (workspace scaffolding), parallel with #656 and #655. Retarget to `feat/PYSDK-133/python-sdk-slim` first.

## Summary

Updates all dev tooling configuration to understand the new uv workspace layout introduced by PYSDK-134. Source code has NOT moved yet (PYSDK-135 is a parallel PR) — tool paths point to the new package locations and lint/type-check errors from missing source files are expected until PYSDK-135 merges.

## Files changed

- **`noxfile.py`**
  - `lint` session: `mypy` target updated from `src` to `packages/aignostics-sdk/src packages/aignostics/src`
  - `dist` session: now builds both `aignostics-sdk` and `aignostics` packages with `--package` flag
  - Fixed four Pylance/pyright type-narrowing errors in latexmk version detection (`session.error()` is not typed as `NoReturn` in nox stubs, so `re.Match | None` was not narrowed after the error call; added `assert ... is not None  # noqa: S101`)

- **`pyrightconfig.json`**
  - Added explicit `include` list targeting `packages/aignostics-sdk/src`, `packages/aignostics/src`, and `noxfile.py`
  - Updated `ignore` paths from `src/aignostics/...` to `packages/aignostics/src/aignostics/...`
  - Updated `extraPaths` from `./src/aignostics/utils` to `./packages/aignostics/src/aignostics/utils`
  - Preserved existing `exclude` entries (nox/.venv/dist etc.)

- **`pyproject.toml`**
  - `[tool.mypy]` `exclude`: updated from `src/aignostics/third_party` glob to explicit new package paths for both `aignostics-sdk` and `aignostics` third-party dirs and excluded files
  - `[tool.pytest.ini_options]` `addopts`: changed `--cov=aignostics` to `--cov=aignostics_sdk --cov=aignostics`
  - `[tool.coverage.run]` `source`: updated from `["src"]` to `["packages/aignostics-sdk/src", "packages/aignostics/src"]`
  - `[tool.coverage.run]` `omit`: updated glob patterns from `src/aignostics/...` to `*/aignostics/...` and `*/aignostics_sdk/...`
  - `[tool.coverage.paths]` `source`: updated to point at both new package source dirs

## What was verified

- `ruff check .` — all checks passed
- `ruff format --check .` — all files already formatted
- `pyright` — 0 errors, 0 warnings
- `mypy packages/aignostics-sdk/src packages/aignostics/src` — success (2 stub `__init__.py` files)
- `python -c "import json; json.load(open('pyrightconfig.json'))"` — valid JSON
- `uv run coverage debug config` — config parses correctly
- `uv sync --all-extras` — workspace resolves cleanly

## Notes

- `ruff.toml` / `[tool.ruff]`: uses glob patterns only (`**/third_party/*.py` etc.) — no path changes needed
- `sonar-project.properties`: uses glob exclusion patterns, no `sonar.sources` property — no changes needed