### PR TITLE
feat(packaging): rewrite all imports from aignostics.* to aignostics_sdk.* [PYSDK-136]

### DIFF
--- a/examples/notebook.py
+++ b/examples/notebook.py
@@ -228,7 +228,7 @@ def _(client):
 def _(mo):
     mo.md(
         r"""
-    from aignostics.platform.resources.runs import ApplicationRun
+    from aignostics_sdk.platform.resources.runs import ApplicationRun
     application_run = ApplicationRun.for_run_id("<run_id>")
     # download
     download_folder = "/tmp/"

--- a/packages/aignostics-sdk/src/aignostics_sdk/platform/_authentication.py
+++ b/packages/aignostics-sdk/src/aignostics_sdk/platform/_authentication.py
@@ -23,14 +23,14 @@ from tenacity import (
     wait_exponential_jitter,
 )
 
-from aignostics.platform._api import _log_retry_attempt
-from aignostics.platform._messages import (
+from aignostics_sdk.platform._api import _log_retry_attempt
+from aignostics_sdk.platform._messages import (
     AUTHENTICATION_FAILED,
     AUTHENTICATION_FAILED_ACCESS_TOKEN_FROM_REFRESH_TOKEN,
     AUTHENTICATION_FAILED_TOKEN_VERIFICATION,
     INVALID_REDIRECT_URI,
 )
-from aignostics.platform._settings import settings
+from aignostics_sdk.platform._settings import settings
 
 CALLBACK_PORT_RETRY_COUNT = 20
 CALLBACK_PORT_BACKOFF_DELAY = 1

--- a/packages/aignostics-sdk/src/aignostics_sdk/platform/_cli.py
+++ b/packages/aignostics-sdk/src/aignostics_sdk/platform/_cli.py
@@ -7,7 +7,7 @@ from typing import Annotated
 import typer
 from loguru import logger
 
-from aignostics.utils import console
+from aignostics_sdk.utils import console
 
 from ._sdk_metadata import get_item_sdk_metadata_json_schema, get_run_sdk_metadata_json_schema
 from ._service import Service

--- a/packages/aignostics-sdk/src/aignostics_sdk/platform/_client.py
+++ b/packages/aignostics-sdk/src/aignostics_sdk/platform/_client.py
@@ -17,17 +17,17 @@ from tenacity import (
     wait_exponential_jitter,
 )
 
-from aignostics.platform._api import (
+from aignostics_sdk.platform._api import (
     RETRYABLE_EXCEPTIONS,
     _AuthenticatedApi,
     _log_retry_attempt,
     _OAuth2TokenProviderConfiguration,
 )
-from aignostics.platform._authentication import get_token
-from aignostics.platform._operation_cache import cached_operation
-from aignostics.platform.resources.applications import Applications, Versions
-from aignostics.platform.resources.runs import Run, Runs
-from aignostics.utils import user_agent
+from aignostics_sdk.platform._authentication import get_token
+from aignostics_sdk.platform._operation_cache import cached_operation
+from aignostics_sdk.platform.resources.applications import Applications, Versions
+from aignostics_sdk.platform.resources.runs import Run, Runs
+from aignostics_sdk.utils import user_agent
 
 from ._settings import settings
 

--- a/packages/aignostics-sdk/src/aignostics_sdk/platform/_sdk_metadata.py
+++ b/packages/aignostics-sdk/src/aignostics_sdk/platform/_sdk_metadata.py
@@ -13,7 +13,7 @@ from typing import Any, Literal
 from loguru import logger
 from pydantic import BaseModel, Field, ValidationError, field_validator, model_validator
 
-from aignostics.utils import user_agent
+from aignostics_sdk.utils import user_agent
 
 from ._constants import (
     DEFAULT_CPU_PROVISIONING_MODE,
@@ -293,7 +293,7 @@ def build_run_sdk_metadata(existing_metadata: dict[str, Any] | None = None) -> d
         dict[str, Any]: Dictionary containing SDK metadata including user agent,
             user information, and optionally CI information (GitHub workflow and pytest test context).
     """
-    from aignostics.platform._client import Client  # noqa: PLC0415
+    from aignostics_sdk.platform._client import Client  # noqa: PLC0415
 
     submission_initiator = "user"  # who/what initiated the run (user, test, bridge)
     submission_interface = "script"  # how the SDK was accessed (script, cli, launchpad)

--- a/packages/aignostics-sdk/src/aignostics_sdk/platform/_service.py
+++ b/packages/aignostics-sdk/src/aignostics_sdk/platform/_service.py
@@ -13,8 +13,8 @@ from aignx.codegen.models import UserReadResponse as User
 from loguru import logger
 from pydantic import BaseModel, computed_field
 
-from aignostics.constants import INTERNAL_ORGS
-from aignostics.utils import BaseService, Health, user_agent
+from aignostics_sdk.constants import INTERNAL_ORGS
+from aignostics_sdk.utils import BaseService, Health, user_agent
 
 from ._authentication import get_token, remove_cached_token, verify_and_decode_token
 from ._client import Client

--- a/packages/aignostics-sdk/src/aignostics_sdk/platform/_settings.py
+++ b/packages/aignostics-sdk/src/aignostics_sdk/platform/_settings.py
@@ -19,7 +19,7 @@ from pydantic import (
 )
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from aignostics.utils import OpaqueSettings, __project_name__, load_settings
+from aignostics_sdk.utils import OpaqueSettings, __project_name__, load_settings
 
 from ._constants import (
     API_ROOT_DEV,

--- a/packages/aignostics-sdk/src/aignostics_sdk/platform/resources/applications.py
+++ b/packages/aignostics-sdk/src/aignostics_sdk/platform/resources/applications.py
@@ -30,17 +30,17 @@ from tenacity import (
     wait_exponential_jitter,
 )
 
-from aignostics.platform._api import (
+from aignostics_sdk.platform._api import (
     RETRYABLE_EXCEPTIONS,
     _AuthenticatedApi,
     _AuthenticatedResource,
     _log_retry_attempt,
 )
-from aignostics.platform._authentication import get_token
-from aignostics.platform._operation_cache import cached_operation
-from aignostics.platform._settings import settings
-from aignostics.platform.resources.utils import paginate
-from aignostics.utils import user_agent
+from aignostics_sdk.platform._authentication import get_token
+from aignostics_sdk.platform._operation_cache import cached_operation
+from aignostics_sdk.platform._settings import settings
+from aignostics_sdk.platform.resources.utils import paginate
+from aignostics_sdk.utils import user_agent
 
 _DOCUMENT_DOWNLOAD_CHUNK_SIZE = 1024 * 1024  # 1 MB
 

--- a/packages/aignostics-sdk/src/aignostics_sdk/platform/resources/runs.py
+++ b/packages/aignostics-sdk/src/aignostics_sdk/platform/resources/runs.py
@@ -49,31 +49,31 @@ from tenacity import (
     wait_exponential_jitter,
 )
 
-from aignostics.platform._api import (
+from aignostics_sdk.platform._api import (
     RETRYABLE_EXCEPTIONS,
     _AuthenticatedApi,
     _AuthenticatedResource,
     _log_retry_attempt,
 )
-from aignostics.platform._authentication import get_token
-from aignostics.platform._operation_cache import cached_operation, operation_cache_clear
-from aignostics.platform._sdk_metadata import (
+from aignostics_sdk.platform._authentication import get_token
+from aignostics_sdk.platform._operation_cache import cached_operation, operation_cache_clear
+from aignostics_sdk.platform._sdk_metadata import (
     build_item_sdk_metadata,
     build_run_sdk_metadata,
     validate_item_sdk_metadata,
     validate_run_sdk_metadata,
 )
-from aignostics.platform._settings import settings
-from aignostics.platform._utils import (
+from aignostics_sdk.platform._settings import settings
+from aignostics_sdk.platform._utils import (
     calculate_file_crc32c,
     convert_to_json_serializable,
     download_file,
     get_mime_type_for_artifact,
     mime_type_to_file_ending,
 )
-from aignostics.platform.resources.applications import Versions
-from aignostics.platform.resources.utils import paginate
-from aignostics.utils import user_agent
+from aignostics_sdk.platform.resources.applications import Versions
+from aignostics_sdk.platform.resources.utils import paginate
+from aignostics_sdk.utils import user_agent
 
 LIST_APPLICATION_RUNS_MAX_PAGE_SIZE = 100
 LIST_APPLICATION_RUNS_MIN_PAGE_SIZE = 5
@@ -263,7 +263,7 @@ class Run(_AuthenticatedResource):
         Returns:
             Run: The initialized Run instance.
         """
-        from aignostics.platform._client import Client  # noqa: PLC0415
+        from aignostics_sdk.platform._client import Client  # noqa: PLC0415
 
         return cls(Client.get_api_client(cache_token=cache_token), run_id)
 

--- a/packages/aignostics-sdk/src/aignostics_sdk/utils/_constants.py
+++ b/packages/aignostics-sdk/src/aignostics_sdk/utils/_constants.py
@@ -8,12 +8,20 @@ from pathlib import Path
 
 from dotenv import load_dotenv
 
-__project_name__ = __name__.split(".")[0]
+# __project_name__ is hardcoded to "aignostics" for backward compatibility:
+# - token cache location stays ~/.aignostics/token.json
+# - environment variable prefix stays AIGNOSTICS_*
+# TODO(PYSDK-136): decide whether to migrate to "aignostics_sdk" as part of a deliberate
+#                  breaking-change release.
+__project_name__ = "aignostics"
+# _package_name is the actual installed Python distribution name ("aignostics-sdk").
+# Used for importlib.metadata calls so they target the correct installed package.
+_package_name = __name__.split(".")[0]  # "aignostics_sdk"
 load_dotenv(str(Path(".env")))
 load_dotenv(os.getenv(f"{__project_name__.upper()}_ENV_FILE", Path.home() / f".{__project_name__}/.env"))
 
 __project_path__ = str(Path(__file__).parent.parent.parent)
-__version__ = metadata.version(__project_name__)
+__version__ = metadata.version(_package_name)
 __build_number__ = os.getenv("GITHUB_RUN_NUMBER") or os.getenv("BUILD_NUMBER") or None
 __version_full__ = f"{__version__}+{__build_number__}" if __build_number__ else __version__
 __python_version__ = platform.python_version()
@@ -94,13 +102,13 @@ def get_project_url_by_label(prefix: str) -> str:
     Returns:
         The extracted URL string if found, or an empty string if not found.
     """
-    for url_entry in metadata.metadata(__project_name__).get_all("Project-URL", []):
+    for url_entry in metadata.metadata(_package_name).get_all("Project-URL", []):
         if url_entry.startswith(prefix):
             return str(url_entry.split(", ", 1)[1])
     return ""
 
 
-_authors = metadata.metadata(__project_name__).get_all("Author-email", [])
+_authors = metadata.metadata(_package_name).get_all("Author-email", [])
 _author = _authors[0] if _authors else None
 __author_name__ = _author.split("<")[0].strip() if _author else None
 __author_email__ = _author.split("<")[1].strip(" >") if _author else None

--- a/packages/aignostics-sdk/src/aignostics_sdk/utils/_fs.py
+++ b/packages/aignostics-sdk/src/aignostics_sdk/utils/_fs.py
@@ -4,9 +4,8 @@ import platform
 from pathlib import Path, PureWindowsPath
 
 import platformdirs
-from loguru import logger
-
 from aignostics.third_party.showinfm.showinfm import show_in_file_manager
+from loguru import logger
 
 from ._constants import __is_running_in_read_only_environment__, __project_name__
 

--- a/packages/aignostics-sdk/src/aignostics_sdk/utils/_mcp.py
+++ b/packages/aignostics-sdk/src/aignostics_sdk/utils/_mcp.py
@@ -13,7 +13,7 @@ Example:
     uv run aignostics mcp list-tools
 
     # Use programmatically
-    from aignostics.utils import mcp_create_server, mcp_run, mcp_list_tools
+    from aignostics_sdk.utils import mcp_create_server, mcp_run, mcp_list_tools
 
     server = mcp_create_server()
     mcp_run()

--- a/packages/aignostics/src/aignostics/__init__.py
+++ b/packages/aignostics/src/aignostics/__init__.py
@@ -14,7 +14,7 @@ from .constants import (  # noqa: E402
     WSI_SUPPORTED_FILE_EXTENSIONS,
     WSI_SUPPORTED_FILE_EXTENSIONS_TEST_APP,
 )
-from .utils.boot import boot  # noqa: E402
+from aignostics_sdk.utils.boot import boot  # noqa: E402
 
 # Add scheme to HTTP proxy environment variables if missing
 for proxy_var in ["HTTP_PROXY", "HTTPS_PROXY"]:

--- a/packages/aignostics/src/aignostics/__init__.py
+++ b/packages/aignostics/src/aignostics/__init__.py
@@ -7,6 +7,8 @@ from typing import Any
 # TODO(Helmut): remove when google_crc32c supports Python 3.14
 warnings.filterwarnings("ignore", message="As the c extension couldn't be imported", category=RuntimeWarning)
 
+from aignostics_sdk.utils.boot import boot  # noqa: E402
+
 from .constants import (  # noqa: E402
     HETA_APPLICATION_ID,
     SENTRY_INTEGRATIONS,
@@ -14,7 +16,6 @@ from .constants import (  # noqa: E402
     WSI_SUPPORTED_FILE_EXTENSIONS,
     WSI_SUPPORTED_FILE_EXTENSIONS_TEST_APP,
 )
-from aignostics_sdk.utils.boot import boot  # noqa: E402
 
 # Add scheme to HTTP proxy environment variables if missing
 for proxy_var in ["HTTP_PROXY", "HTTPS_PROXY"]:

--- a/packages/aignostics/src/aignostics/application/_cli.py
+++ b/packages/aignostics/src/aignostics/application/_cli.py
@@ -12,7 +12,7 @@ import typer
 from loguru import logger
 
 from aignostics.bucket import Service as BucketService
-from aignostics.platform import (
+from aignostics_sdk.platform import (
     DEFAULT_CPU_PROVISIONING_MODE,
     DEFAULT_FLEX_START_MAX_RUN_DURATION_MINUTES,
     DEFAULT_GPU_PROVISIONING_MODE,
@@ -24,9 +24,9 @@ from aignostics.platform import (
     NotFoundException,
     RunState,
 )
-from aignostics.platform import Service as PlatformService
+from aignostics_sdk.platform import Service as PlatformService
 from aignostics.system import Service as SystemService
-from aignostics.utils import console, get_user_data_directory, sanitize_path
+from aignostics_sdk.utils import console, get_user_data_directory, sanitize_path
 
 from ._models import DownloadProgress, DownloadProgressState
 from ._service import Service

--- a/packages/aignostics/src/aignostics/application/_cli.py
+++ b/packages/aignostics/src/aignostics/application/_cli.py
@@ -9,9 +9,6 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
-from loguru import logger
-
-from aignostics.bucket import Service as BucketService
 from aignostics_sdk.platform import (
     DEFAULT_CPU_PROVISIONING_MODE,
     DEFAULT_FLEX_START_MAX_RUN_DURATION_MINUTES,
@@ -25,8 +22,11 @@ from aignostics_sdk.platform import (
     RunState,
 )
 from aignostics_sdk.platform import Service as PlatformService
-from aignostics.system import Service as SystemService
 from aignostics_sdk.utils import console, get_user_data_directory, sanitize_path
+from loguru import logger
+
+from aignostics.bucket import Service as BucketService
+from aignostics.system import Service as SystemService
 
 from ._models import DownloadProgress, DownloadProgressState
 from ._service import Service

--- a/packages/aignostics/src/aignostics/application/_download.py
+++ b/packages/aignostics/src/aignostics/application/_download.py
@@ -8,10 +8,9 @@ from urllib.parse import urlparse
 
 import crc32c
 import requests
-from loguru import logger
-
 from aignostics_sdk.platform import ArtifactOutput, ItemOutput, ItemState, Run, generate_signed_url
 from aignostics_sdk.utils import sanitize_path_component
+from loguru import logger
 
 from ._models import DownloadProgress, DownloadProgressState
 from ._utils import get_file_extension_for_artifact

--- a/packages/aignostics/src/aignostics/application/_download.py
+++ b/packages/aignostics/src/aignostics/application/_download.py
@@ -10,8 +10,8 @@ import crc32c
 import requests
 from loguru import logger
 
-from aignostics.platform import ArtifactOutput, ItemOutput, ItemState, Run, generate_signed_url
-from aignostics.utils import sanitize_path_component
+from aignostics_sdk.platform import ArtifactOutput, ItemOutput, ItemState, Run, generate_signed_url
+from aignostics_sdk.utils import sanitize_path_component
 
 from ._models import DownloadProgress, DownloadProgressState
 from ._utils import get_file_extension_for_artifact

--- a/packages/aignostics/src/aignostics/application/_gui/_frame.py
+++ b/packages/aignostics/src/aignostics/application/_gui/_frame.py
@@ -2,11 +2,10 @@ from datetime import UTC, datetime
 from typing import Any
 
 import humanize
+from aignostics.gui import frame
 from loguru import logger
 from nicegui import app, background_tasks, context, ui  # noq
 from nicegui import run as nicegui_run
-
-from aignostics.gui import frame
 
 from .._service import Service  # noqa: TID252
 from ._utils import application_id_to_icon, run_status_to_icon_and_color

--- a/packages/aignostics/src/aignostics/application/_gui/_page_application_describe.py
+++ b/packages/aignostics/src/aignostics/application/_gui/_page_application_describe.py
@@ -13,7 +13,7 @@ from nicegui import run as nicegui_run
 from nicegui.events import ValueChangeEventArguments
 
 from aignostics.constants import WSI_SUPPORTED_FILE_EXTENSIONS
-from aignostics.platform import (
+from aignostics_sdk.platform import (
     DEFAULT_CPU_PROVISIONING_MODE,
     DEFAULT_FLEX_START_MAX_RUN_DURATION_MINUTES,
     DEFAULT_GPU_PROVISIONING_MODE,
@@ -22,10 +22,10 @@ from aignostics.platform import (
     DEFAULT_NODE_ACQUISITION_TIMEOUT_MINUTES,
 )
 from aignostics.system import Service as SystemService
-from aignostics.utils import GUILocalFilePicker, get_user_data_directory
+from aignostics_sdk.utils import GUILocalFilePicker, get_user_data_directory
 
 if TYPE_CHECKING:
-    from aignostics.platform import UserInfo
+    from aignostics_sdk.platform import UserInfo
 
 from .._service import Service  # noqa: TID252
 from .._utils import get_mime_type_for_artifact  # noqa: TID252

--- a/packages/aignostics/src/aignostics/application/_gui/_page_application_describe.py
+++ b/packages/aignostics/src/aignostics/application/_gui/_page_application_describe.py
@@ -7,12 +7,8 @@ from multiprocessing import Manager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from loguru import logger
-from nicegui import app, binding, ui
-from nicegui import run as nicegui_run
-from nicegui.events import ValueChangeEventArguments
-
 from aignostics.constants import WSI_SUPPORTED_FILE_EXTENSIONS
+from aignostics.system import Service as SystemService
 from aignostics_sdk.platform import (
     DEFAULT_CPU_PROVISIONING_MODE,
     DEFAULT_FLEX_START_MAX_RUN_DURATION_MINUTES,
@@ -21,8 +17,11 @@ from aignostics_sdk.platform import (
     DEFAULT_MAX_GPUS_PER_SLIDE,
     DEFAULT_NODE_ACQUISITION_TIMEOUT_MINUTES,
 )
-from aignostics.system import Service as SystemService
 from aignostics_sdk.utils import GUILocalFilePicker, get_user_data_directory
+from loguru import logger
+from nicegui import app, binding, ui
+from nicegui import run as nicegui_run
+from nicegui.events import ValueChangeEventArguments
 
 if TYPE_CHECKING:
     from aignostics_sdk.platform import UserInfo

--- a/packages/aignostics/src/aignostics/application/_gui/_page_application_run_describe.py
+++ b/packages/aignostics/src/aignostics/application/_gui/_page_application_run_describe.py
@@ -19,14 +19,14 @@ from nicegui import (
 )
 from nicegui import run as nicegui_run
 
-from aignostics.platform import ArtifactOutput, ItemOutput, ItemResult, ItemState, Run, RunState
+from aignostics_sdk.platform import ArtifactOutput, ItemOutput, ItemResult, ItemState, Run, RunState
 from aignostics.third_party.showinfm.showinfm import show_in_file_manager
-from aignostics.utils import GUILocalFilePicker, get_user_data_directory
+from aignostics_sdk.utils import GUILocalFilePicker, get_user_data_directory
 
 if TYPE_CHECKING:
     from aignx.codegen.models import RunReadResponse
 
-    from aignostics.platform import UserInfo
+    from aignostics_sdk.platform import UserInfo
 
 from .._models import DownloadProgressState  # noqa: TID252
 from .._service import Service  # noqa: TID252

--- a/packages/aignostics/src/aignostics/application/_gui/_page_application_run_describe.py
+++ b/packages/aignostics/src/aignostics/application/_gui/_page_application_run_describe.py
@@ -12,6 +12,9 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
 
 import humanize
+from aignostics.third_party.showinfm.showinfm import show_in_file_manager
+from aignostics_sdk.platform import ArtifactOutput, ItemOutput, ItemResult, ItemState, Run, RunState
+from aignostics_sdk.utils import GUILocalFilePicker, get_user_data_directory
 from loguru import logger
 from nicegui import (
     app,
@@ -19,14 +22,9 @@ from nicegui import (
 )
 from nicegui import run as nicegui_run
 
-from aignostics_sdk.platform import ArtifactOutput, ItemOutput, ItemResult, ItemState, Run, RunState
-from aignostics.third_party.showinfm.showinfm import show_in_file_manager
-from aignostics_sdk.utils import GUILocalFilePicker, get_user_data_directory
-
 if TYPE_CHECKING:
-    from aignx.codegen.models import RunReadResponse
-
     from aignostics_sdk.platform import UserInfo
+    from aignx.codegen.models import RunReadResponse
 
 from .._models import DownloadProgressState  # noqa: TID252
 from .._service import Service  # noqa: TID252

--- a/packages/aignostics/src/aignostics/application/_gui/_page_builder.py
+++ b/packages/aignostics/src/aignostics/application/_gui/_page_builder.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from aignostics.utils import BasePageBuilder
+from aignostics_sdk.utils import BasePageBuilder
 
 HOME_PAGE_TIMEOUT_SECONDS = 30
 APPLICATION_DESCRIBE_PAGE_TIMEOUT_SECONDS = 30

--- a/packages/aignostics/src/aignostics/application/_gui/_utils.py
+++ b/packages/aignostics/src/aignostics/application/_gui/_utils.py
@@ -1,6 +1,6 @@
 """Utility functions for the application GUI."""
 
-from aignostics.platform import ItemState, ItemTerminationReason, RunState, RunTerminationReason
+from aignostics_sdk.platform import ItemState, ItemTerminationReason, RunState, RunTerminationReason
 
 NONE = "none"
 

--- a/packages/aignostics/src/aignostics/application/_models.py
+++ b/packages/aignostics/src/aignostics/application/_models.py
@@ -4,9 +4,8 @@ from enum import StrEnum
 from importlib.util import find_spec
 from pathlib import Path
 
-from pydantic import BaseModel, computed_field
-
 from aignostics_sdk.platform import ItemResult, OutputArtifactElement, RunData
+from pydantic import BaseModel, computed_field
 
 has_qupath_extra = find_spec("ijson")
 if has_qupath_extra:

--- a/packages/aignostics/src/aignostics/application/_models.py
+++ b/packages/aignostics/src/aignostics/application/_models.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from pydantic import BaseModel, computed_field
 
-from aignostics.platform import ItemResult, OutputArtifactElement, RunData
+from aignostics_sdk.platform import ItemResult, OutputArtifactElement, RunData
 
 has_qupath_extra = find_spec("ijson")
 if has_qupath_extra:

--- a/packages/aignostics/src/aignostics/application/_service.py
+++ b/packages/aignostics/src/aignostics/application/_service.py
@@ -16,7 +16,7 @@ from loguru import logger
 
 from aignostics.bucket import Service as BucketService
 from aignostics.constants import TEST_APP_APPLICATION_ID
-from aignostics.platform import (
+from aignostics_sdk.platform import (
     LIST_APPLICATION_RUNS_MAX_PAGE_SIZE,
     ApiException,
     Application,
@@ -32,8 +32,8 @@ from aignostics.platform import (
     RunOutput,
     RunState,
 )
-from aignostics.platform import Service as PlatformService
-from aignostics.utils import BaseService, Health, sanitize_path_component
+from aignostics_sdk.platform import Service as PlatformService
+from aignostics_sdk.utils import BaseService, Health, sanitize_path_component
 from aignostics.wsi import Service as WSIService
 
 from ._download import (
@@ -1089,7 +1089,7 @@ class Service(BaseService):  # noqa: PLR0904
 
             # Validate pipeline configuration if present
             if "pipeline" in sdk_metadata:
-                from aignostics.platform._sdk_metadata import PipelineConfig  # noqa: PLC0415
+                from aignostics_sdk.platform._sdk_metadata import PipelineConfig  # noqa: PLC0415
 
                 try:
                     PipelineConfig.model_validate(sdk_metadata["pipeline"])

--- a/packages/aignostics/src/aignostics/application/_service.py
+++ b/packages/aignostics/src/aignostics/application/_service.py
@@ -12,10 +12,6 @@ from typing import Any
 
 import crc32c
 import requests
-from loguru import logger
-
-from aignostics.bucket import Service as BucketService
-from aignostics.constants import TEST_APP_APPLICATION_ID
 from aignostics_sdk.platform import (
     LIST_APPLICATION_RUNS_MAX_PAGE_SIZE,
     ApiException,
@@ -34,6 +30,10 @@ from aignostics_sdk.platform import (
 )
 from aignostics_sdk.platform import Service as PlatformService
 from aignostics_sdk.utils import BaseService, Health, sanitize_path_component
+from loguru import logger
+
+from aignostics.bucket import Service as BucketService
+from aignostics.constants import TEST_APP_APPLICATION_ID
 from aignostics.wsi import Service as WSIService
 
 from ._download import (
@@ -1089,7 +1089,7 @@ class Service(BaseService):  # noqa: PLR0904
 
             # Validate pipeline configuration if present
             if "pipeline" in sdk_metadata:
-                from aignostics_sdk.platform._sdk_metadata import PipelineConfig  # noqa: PLC0415
+                from aignostics_sdk.platform._sdk_metadata import PipelineConfig  # noqa: PLC0415, PLC2701
 
                 try:
                     PipelineConfig.model_validate(sdk_metadata["pipeline"])

--- a/packages/aignostics/src/aignostics/application/_settings.py
+++ b/packages/aignostics/src/aignostics/application/_settings.py
@@ -1,8 +1,7 @@
 """Settings of the application module."""
 
+from aignostics_sdk.utils import OpaqueSettings, __env_file__, __project_name__
 from pydantic_settings import SettingsConfigDict
-
-from aignostics_sdk.utils import OpaqueSettings, __env_file__, __project_name__  # noqa: TID252
 
 
 class Settings(OpaqueSettings):

--- a/packages/aignostics/src/aignostics/application/_settings.py
+++ b/packages/aignostics/src/aignostics/application/_settings.py
@@ -2,7 +2,7 @@
 
 from pydantic_settings import SettingsConfigDict
 
-from ..utils import OpaqueSettings, __env_file__, __project_name__  # noqa: TID252
+from aignostics_sdk.utils import OpaqueSettings, __env_file__, __project_name__  # noqa: TID252
 
 
 class Settings(OpaqueSettings):

--- a/packages/aignostics/src/aignostics/application/_utils.py
+++ b/packages/aignostics/src/aignostics/application/_utils.py
@@ -24,7 +24,7 @@ from aignostics.constants import (
     WSI_SUPPORTED_FILE_EXTENSIONS,
     WSI_SUPPORTED_FILE_EXTENSIONS_TEST_APP,
 )
-from aignostics.platform import (
+from aignostics_sdk.platform import (
     InputArtifactData,
     ItemState,
     OutputArtifactData,
@@ -34,7 +34,7 @@ from aignostics.platform import (
     RunItemStatistics,
     RunState,
 )
-from aignostics.utils import console
+from aignostics_sdk.utils import console
 
 RUN_FAILED_MESSAGE = "Failed to get status for run with ID '%s'"
 

--- a/packages/aignostics/src/aignostics/application/_utils.py
+++ b/packages/aignostics/src/aignostics/application/_utils.py
@@ -16,14 +16,6 @@ from pathlib import Path
 from typing import Any, Protocol
 
 import humanize
-from loguru import logger
-
-from aignostics.constants import (
-    HETA_APPLICATION_ID,
-    TEST_APP_APPLICATION_ID,
-    WSI_SUPPORTED_FILE_EXTENSIONS,
-    WSI_SUPPORTED_FILE_EXTENSIONS_TEST_APP,
-)
 from aignostics_sdk.platform import (
     InputArtifactData,
     ItemState,
@@ -35,6 +27,14 @@ from aignostics_sdk.platform import (
     RunState,
 )
 from aignostics_sdk.utils import console
+from loguru import logger
+
+from aignostics.constants import (
+    HETA_APPLICATION_ID,
+    TEST_APP_APPLICATION_ID,
+    WSI_SUPPORTED_FILE_EXTENSIONS,
+    WSI_SUPPORTED_FILE_EXTENSIONS_TEST_APP,
+)
 
 RUN_FAILED_MESSAGE = "Failed to get status for run with ID '%s'"
 

--- a/packages/aignostics/src/aignostics/bucket/_cli.py
+++ b/packages/aignostics/src/aignostics/bucket/_cli.py
@@ -12,7 +12,7 @@ import humanize
 import typer
 from loguru import logger
 
-from aignostics.utils import console, get_user_data_directory
+from aignostics_sdk.utils import console, get_user_data_directory
 
 from ._service import DownloadProgress, Service
 

--- a/packages/aignostics/src/aignostics/bucket/_cli.py
+++ b/packages/aignostics/src/aignostics/bucket/_cli.py
@@ -10,9 +10,8 @@ from typing import Annotated
 
 import humanize
 import typer
-from loguru import logger
-
 from aignostics_sdk.utils import console, get_user_data_directory
+from loguru import logger
 
 from ._service import DownloadProgress, Service
 

--- a/packages/aignostics/src/aignostics/bucket/_gui.py
+++ b/packages/aignostics/src/aignostics/bucket/_gui.py
@@ -7,9 +7,9 @@ import humanize
 
 from aignostics.gui import frame
 from aignostics.third_party.showinfm.showinfm import show_in_file_manager
-from aignostics.utils import get_user_data_directory
+from aignostics_sdk.utils import get_user_data_directory
 
-from ..utils import BasePageBuilder, GUILocalFilePicker  # noqa: TID252
+from aignostics_sdk.utils import BasePageBuilder, GUILocalFilePicker  # noqa: TID252
 from ._service import DownloadProgress, Service
 
 MESSAGE_NO_DOWNLOAD_FOLDER_SELECTED = "No download folder selected"

--- a/packages/aignostics/src/aignostics/bucket/_gui.py
+++ b/packages/aignostics/src/aignostics/bucket/_gui.py
@@ -4,12 +4,11 @@ from multiprocessing import Manager
 from pathlib import Path
 
 import humanize
+from aignostics_sdk.utils import BasePageBuilder, GUILocalFilePicker, get_user_data_directory
 
 from aignostics.gui import frame
 from aignostics.third_party.showinfm.showinfm import show_in_file_manager
-from aignostics_sdk.utils import get_user_data_directory
 
-from aignostics_sdk.utils import BasePageBuilder, GUILocalFilePicker  # noqa: TID252
 from ._service import DownloadProgress, Service
 
 MESSAGE_NO_DOWNLOAD_FOLDER_SELECTED = "No download folder selected"

--- a/packages/aignostics/src/aignostics/bucket/_service.py
+++ b/packages/aignostics/src/aignostics/bucket/_service.py
@@ -15,8 +15,8 @@ from pydantic import BaseModel, computed_field
 if TYPE_CHECKING:
     from botocore.client import BaseClient
 
-from aignostics.platform import Service as PlatformService
-from aignostics.utils import BaseService, Health, get_user_data_directory
+from aignostics_sdk.platform import Service as PlatformService
+from aignostics_sdk.utils import BaseService, Health, get_user_data_directory
 
 from ._settings import Settings
 

--- a/packages/aignostics/src/aignostics/bucket/_settings.py
+++ b/packages/aignostics/src/aignostics/bucket/_settings.py
@@ -6,7 +6,7 @@ from typing import Annotated
 from pydantic import Field
 from pydantic_settings import SettingsConfigDict
 
-from ..utils import OpaqueSettings, __env_file__, __project_name__  # noqa: TID252
+from aignostics_sdk.utils import OpaqueSettings, __env_file__, __project_name__  # noqa: TID252
 
 
 class BucketProtocol(StrEnum):

--- a/packages/aignostics/src/aignostics/bucket/_settings.py
+++ b/packages/aignostics/src/aignostics/bucket/_settings.py
@@ -3,10 +3,9 @@
 from enum import StrEnum
 from typing import Annotated
 
+from aignostics_sdk.utils import OpaqueSettings, __env_file__, __project_name__
 from pydantic import Field
 from pydantic_settings import SettingsConfigDict
-
-from aignostics_sdk.utils import OpaqueSettings, __env_file__, __project_name__  # noqa: TID252
 
 
 class BucketProtocol(StrEnum):

--- a/packages/aignostics/src/aignostics/cli.py
+++ b/packages/aignostics/src/aignostics/cli.py
@@ -8,7 +8,7 @@ import typer
 from loguru import logger
 
 from aignostics.constants import NOTEBOOK_DEFAULT, WINDOW_TITLE
-from aignostics.utils import (
+from aignostics_sdk.utils import (
     __is_running_in_container__,
     __python_version__,
     __version__,
@@ -25,7 +25,7 @@ if find_spec("nicegui") and find_spec("webview") and not __is_running_in_contain
     @cli.command()
     def launchpad() -> None:
         """Open Aignostics Launchpad, the graphical user interface of the Aignostics Platform."""
-        from aignostics.utils import gui_run  # noqa: PLC0415
+        from aignostics_sdk.utils import gui_run  # noqa: PLC0415
 
         gui_run(native=True, with_api=False, title=WINDOW_TITLE, icon="🔬")
 
@@ -33,7 +33,7 @@ if find_spec("nicegui") and find_spec("webview") and not __is_running_in_contain
 if find_spec("marimo"):
     from typing import Annotated
 
-    from aignostics.utils import create_marimo_app
+    from aignostics_sdk.utils import create_marimo_app
 
     @cli.command()
     def notebook(
@@ -79,7 +79,7 @@ def mcp_run() -> None:
     Examples:
         uv run aignostics mcp run
     """
-    from aignostics.utils import mcp_run  # noqa: PLC0415
+    from aignostics_sdk.utils import mcp_run  # noqa: PLC0415
 
     mcp_run()
 
@@ -99,7 +99,7 @@ def mcp_list_tools() -> None:
 
     from rich.table import Table  # noqa: PLC0415
 
-    from aignostics.utils import mcp_list_tools  # noqa: PLC0415
+    from aignostics_sdk.utils import mcp_list_tools  # noqa: PLC0415
 
     tools = mcp_list_tools()
 

--- a/packages/aignostics/src/aignostics/cli.py
+++ b/packages/aignostics/src/aignostics/cli.py
@@ -5,9 +5,6 @@ from importlib.util import find_spec
 from pathlib import Path
 
 import typer
-from loguru import logger
-
-from aignostics.constants import NOTEBOOK_DEFAULT, WINDOW_TITLE
 from aignostics_sdk.utils import (
     __is_running_in_container__,
     __python_version__,
@@ -15,6 +12,9 @@ from aignostics_sdk.utils import (
     console,
     prepare_cli,
 )
+from loguru import logger
+
+from aignostics.constants import NOTEBOOK_DEFAULT, WINDOW_TITLE
 
 cli = typer.Typer(
     help="Command Line Interface (CLI) of Aignostics Python SDK providing access to Aignostics Platform.",
@@ -97,9 +97,8 @@ def mcp_list_tools() -> None:
     """
     import operator  # noqa: PLC0415
 
-    from rich.table import Table  # noqa: PLC0415
-
     from aignostics_sdk.utils import mcp_list_tools  # noqa: PLC0415
+    from rich.table import Table  # noqa: PLC0415
 
     tools = mcp_list_tools()
 

--- a/packages/aignostics/src/aignostics/constants.py
+++ b/packages/aignostics/src/aignostics/constants.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from aignostics.utils import __version__
+from aignostics_sdk.utils import __version__
 
 if TYPE_CHECKING:
     from sentry_sdk.integrations import Integration

--- a/packages/aignostics/src/aignostics/dataset/_cli.py
+++ b/packages/aignostics/src/aignostics/dataset/_cli.py
@@ -6,9 +6,8 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
-from loguru import logger
-
 from aignostics_sdk.utils import console, get_user_data_directory
+from loguru import logger
 
 PATH_LENGTH_MAX = 260
 TARGET_LAYOUT_DEFAULT = "%collection_id/%PatientID/%StudyInstanceUID/%Modality_%SeriesInstanceUID/"

--- a/packages/aignostics/src/aignostics/dataset/_cli.py
+++ b/packages/aignostics/src/aignostics/dataset/_cli.py
@@ -8,7 +8,7 @@ from typing import Annotated
 import typer
 from loguru import logger
 
-from aignostics.utils import console, get_user_data_directory
+from aignostics_sdk.utils import console, get_user_data_directory
 
 PATH_LENGTH_MAX = 260
 TARGET_LAYOUT_DEFAULT = "%collection_id/%PatientID/%StudyInstanceUID/%Modality_%SeriesInstanceUID/"

--- a/packages/aignostics/src/aignostics/dataset/_gui.py
+++ b/packages/aignostics/src/aignostics/dataset/_gui.py
@@ -3,11 +3,11 @@
 from multiprocessing import Manager
 from pathlib import Path
 
+from aignostics_sdk.utils import BasePageBuilder, GUILocalFilePicker, get_user_data_directory
+
 from aignostics.gui import frame
 from aignostics.third_party.showinfm.showinfm import show_in_file_manager
-from aignostics_sdk.utils import get_user_data_directory
 
-from aignostics_sdk.utils import BasePageBuilder, GUILocalFilePicker  # noqa: TID252
 from ._service import TARGET_LAYOUT_DEFAULT, Service
 
 MESSAGE_NO_DOWNLOAD_FOLDER_SELECTED = "No download folder selected"

--- a/packages/aignostics/src/aignostics/dataset/_gui.py
+++ b/packages/aignostics/src/aignostics/dataset/_gui.py
@@ -5,9 +5,9 @@ from pathlib import Path
 
 from aignostics.gui import frame
 from aignostics.third_party.showinfm.showinfm import show_in_file_manager
-from aignostics.utils import get_user_data_directory
+from aignostics_sdk.utils import get_user_data_directory
 
-from ..utils import BasePageBuilder, GUILocalFilePicker  # noqa: TID252
+from aignostics_sdk.utils import BasePageBuilder, GUILocalFilePicker  # noqa: TID252
 from ._service import TARGET_LAYOUT_DEFAULT, Service
 
 MESSAGE_NO_DOWNLOAD_FOLDER_SELECTED = "No download folder selected"

--- a/packages/aignostics/src/aignostics/dataset/_service.py
+++ b/packages/aignostics/src/aignostics/dataset/_service.py
@@ -14,8 +14,8 @@ from typing import Any
 import requests
 from loguru import logger
 
-from aignostics.platform import generate_signed_url as platform_generate_signed_url
-from aignostics.utils import SUBPROCESS_CREATION_FLAGS, BaseService, Health
+from aignostics_sdk.platform import generate_signed_url as platform_generate_signed_url
+from aignostics_sdk.utils import SUBPROCESS_CREATION_FLAGS, BaseService, Health
 
 PATH_LENGTH_MAX = 260
 TARGET_LAYOUT_DEFAULT = "%collection_id/%PatientID/%StudyInstanceUID/%Modality_%SeriesInstanceUID/"

--- a/packages/aignostics/src/aignostics/dataset/_service.py
+++ b/packages/aignostics/src/aignostics/dataset/_service.py
@@ -12,10 +12,9 @@ from pathlib import Path
 from typing import Any
 
 import requests
-from loguru import logger
-
 from aignostics_sdk.platform import generate_signed_url as platform_generate_signed_url
 from aignostics_sdk.utils import SUBPROCESS_CREATION_FLAGS, BaseService, Health
+from loguru import logger
 
 PATH_LENGTH_MAX = 260
 TARGET_LAYOUT_DEFAULT = "%collection_id/%PatientID/%StudyInstanceUID/%Modality_%SeriesInstanceUID/"

--- a/packages/aignostics/src/aignostics/gui/_error.py
+++ b/packages/aignostics/src/aignostics/gui/_error.py
@@ -2,7 +2,7 @@
 
 import traceback
 
-from ..utils import BasePageBuilder  # noqa: TID252
+from aignostics_sdk.utils import BasePageBuilder  # noqa: TID252
 from ._frame import frame
 
 

--- a/packages/aignostics/src/aignostics/gui/_error.py
+++ b/packages/aignostics/src/aignostics/gui/_error.py
@@ -2,7 +2,8 @@
 
 import traceback
 
-from aignostics_sdk.utils import BasePageBuilder  # noqa: TID252
+from aignostics_sdk.utils import BasePageBuilder
+
 from ._frame import frame
 
 

--- a/packages/aignostics/src/aignostics/gui/_frame.py
+++ b/packages/aignostics/src/aignostics/gui/_frame.py
@@ -10,12 +10,12 @@ from importlib.util import find_spec
 from typing import Any
 from urllib.parse import urljoin
 
+from aignostics_sdk.utils import __version__, open_user_data_directory
 from html_sanitizer import Sanitizer
 from humanize import naturaldelta
 from loguru import logger
 
 from aignostics.constants import WINDOW_TITLE
-from aignostics_sdk.utils import __version__, open_user_data_directory
 
 from ._theme import theme
 
@@ -50,12 +50,12 @@ def frame(  # noqa: C901, PLR0915
     Yields:
         Generator[Any, Any, Any]: The context manager for the page frame.
     """
-    from nicegui import app, background_tasks, context, run, ui  # noqa: PLC0415
-
     from aignostics_sdk.platform import Service as PlatformService  # noqa: PLC0415
     from aignostics_sdk.platform import UserInfo, settings  # noqa: PLC0415
-    from aignostics.system import Service as SystemService  # noqa: PLC0415
     from aignostics_sdk.utils import NavItem, gui_get_nav_groups  # noqa: PLC0415
+    from nicegui import app, background_tasks, context, run, ui  # noqa: PLC0415
+
+    from aignostics.system import Service as SystemService  # noqa: PLC0415
 
     theme()
 

--- a/packages/aignostics/src/aignostics/gui/_frame.py
+++ b/packages/aignostics/src/aignostics/gui/_frame.py
@@ -15,7 +15,7 @@ from humanize import naturaldelta
 from loguru import logger
 
 from aignostics.constants import WINDOW_TITLE
-from aignostics.utils import __version__, open_user_data_directory
+from aignostics_sdk.utils import __version__, open_user_data_directory
 
 from ._theme import theme
 
@@ -52,10 +52,10 @@ def frame(  # noqa: C901, PLR0915
     """
     from nicegui import app, background_tasks, context, run, ui  # noqa: PLC0415
 
-    from aignostics.platform import Service as PlatformService  # noqa: PLC0415
-    from aignostics.platform import UserInfo, settings  # noqa: PLC0415
+    from aignostics_sdk.platform import Service as PlatformService  # noqa: PLC0415
+    from aignostics_sdk.platform import UserInfo, settings  # noqa: PLC0415
     from aignostics.system import Service as SystemService  # noqa: PLC0415
-    from aignostics.utils import NavItem, gui_get_nav_groups  # noqa: PLC0415
+    from aignostics_sdk.utils import NavItem, gui_get_nav_groups  # noqa: PLC0415
 
     theme()
 

--- a/packages/aignostics/src/aignostics/gui/_theme.py
+++ b/packages/aignostics/src/aignostics/gui/_theme.py
@@ -2,7 +2,7 @@
 
 from pathlib import Path
 
-from aignostics.utils import BasePageBuilder
+from aignostics_sdk.utils import BasePageBuilder
 
 
 class PageBuilder(BasePageBuilder):

--- a/packages/aignostics/src/aignostics/notebook/_gui.py
+++ b/packages/aignostics/src/aignostics/notebook/_gui.py
@@ -3,10 +3,10 @@
 from pathlib import Path
 from urllib.parse import quote
 
+from aignostics_sdk.utils import BasePageBuilder, get_user_data_directory
 from loguru import logger
 
 from aignostics.gui import frame, theme
-from aignostics_sdk.utils import BasePageBuilder, get_user_data_directory
 
 
 class PageBuilder(BasePageBuilder):

--- a/packages/aignostics/src/aignostics/notebook/_gui.py
+++ b/packages/aignostics/src/aignostics/notebook/_gui.py
@@ -6,7 +6,7 @@ from urllib.parse import quote
 from loguru import logger
 
 from aignostics.gui import frame, theme
-from aignostics.utils import BasePageBuilder, get_user_data_directory
+from aignostics_sdk.utils import BasePageBuilder, get_user_data_directory
 
 
 class PageBuilder(BasePageBuilder):

--- a/packages/aignostics/src/aignostics/notebook/_notebook.py
+++ b/packages/aignostics/src/aignostics/notebook/_notebook.py
@@ -29,7 +29,7 @@ def _():
     from dotenv import load_dotenv
     from aignostics import dataset, WSI_SUPPORTED_FILE_EXTENSIONS
     from wsidicom import WsiDicom
-    from aignostics.utils import get_user_data_directory
+    from aignostics_sdk.utils import get_user_data_directory
 
     mo.sidebar([
         mo.md("# aignostics"),

--- a/packages/aignostics/src/aignostics/notebook/_service.py
+++ b/packages/aignostics/src/aignostics/notebook/_service.py
@@ -7,10 +7,10 @@ from subprocess import PIPE, STDOUT, Popen
 from threading import Event, Thread
 from typing import Any
 
+from aignostics_sdk.utils import SUBPROCESS_CREATION_FLAGS, BaseService, Health, get_user_data_directory
 from loguru import logger
 
 from aignostics.constants import NOTEBOOK_DEFAULT
-from aignostics_sdk.utils import SUBPROCESS_CREATION_FLAGS, BaseService, Health, get_user_data_directory
 
 MARIMO_SERVER_STARTUP_TIMEOUT = 60
 

--- a/packages/aignostics/src/aignostics/notebook/_service.py
+++ b/packages/aignostics/src/aignostics/notebook/_service.py
@@ -10,7 +10,7 @@ from typing import Any
 from loguru import logger
 
 from aignostics.constants import NOTEBOOK_DEFAULT
-from aignostics.utils import SUBPROCESS_CREATION_FLAGS, BaseService, Health, get_user_data_directory
+from aignostics_sdk.utils import SUBPROCESS_CREATION_FLAGS, BaseService, Health, get_user_data_directory
 
 MARIMO_SERVER_STARTUP_TIMEOUT = 60
 

--- a/packages/aignostics/src/aignostics/qupath/_cli.py
+++ b/packages/aignostics/src/aignostics/qupath/_cli.py
@@ -9,7 +9,7 @@ import typer
 from loguru import logger
 from rich.table import Table
 
-from aignostics.utils import console
+from aignostics_sdk.utils import console
 
 from ._service import QUPATH_VERSION, Service
 

--- a/packages/aignostics/src/aignostics/qupath/_cli.py
+++ b/packages/aignostics/src/aignostics/qupath/_cli.py
@@ -6,10 +6,9 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
+from aignostics_sdk.utils import console
 from loguru import logger
 from rich.table import Table
-
-from aignostics_sdk.utils import console
 
 from ._service import QUPATH_VERSION, Service
 

--- a/packages/aignostics/src/aignostics/qupath/_gui.py
+++ b/packages/aignostics/src/aignostics/qupath/_gui.py
@@ -8,7 +8,7 @@ import humanize
 from loguru import logger
 
 from aignostics.gui import frame
-from aignostics.utils import BasePageBuilder
+from aignostics_sdk.utils import BasePageBuilder
 
 from ._service import InstallProgress, InstallProgressState, Service
 

--- a/packages/aignostics/src/aignostics/qupath/_gui.py
+++ b/packages/aignostics/src/aignostics/qupath/_gui.py
@@ -5,10 +5,10 @@ from multiprocessing import Manager
 from pathlib import Path
 
 import humanize
+from aignostics_sdk.utils import BasePageBuilder
 from loguru import logger
 
 from aignostics.gui import frame
-from aignostics_sdk.utils import BasePageBuilder
 
 from ._service import InstallProgress, InstallProgressState, Service
 

--- a/packages/aignostics/src/aignostics/qupath/_service.py
+++ b/packages/aignostics/src/aignostics/qupath/_service.py
@@ -26,7 +26,7 @@ from packaging.version import Version
 from psutil import Process, wait_procs
 from pydantic import BaseModel, computed_field
 
-from aignostics.utils import (
+from aignostics_sdk.utils import (
     SUBPROCESS_CREATION_FLAGS,
     BaseService,
     Health,

--- a/packages/aignostics/src/aignostics/qupath/_service.py
+++ b/packages/aignostics/src/aignostics/qupath/_service.py
@@ -21,17 +21,16 @@ import ijson
 import platformdirs
 import psutil
 import requests
-from loguru import logger
-from packaging.version import Version
-from psutil import Process, wait_procs
-from pydantic import BaseModel, computed_field
-
 from aignostics_sdk.utils import (
     SUBPROCESS_CREATION_FLAGS,
     BaseService,
     Health,
     __project_name__,
 )
+from loguru import logger
+from packaging.version import Version
+from psutil import Process, wait_procs
+from pydantic import BaseModel, computed_field
 
 from ._settings import Settings
 

--- a/packages/aignostics/src/aignostics/qupath/_settings.py
+++ b/packages/aignostics/src/aignostics/qupath/_settings.py
@@ -1,8 +1,7 @@
 """Settings of the QuPath module."""
 
+from aignostics_sdk.utils import OpaqueSettings, __env_file__, __project_name__
 from pydantic_settings import SettingsConfigDict
-
-from aignostics_sdk.utils import OpaqueSettings, __env_file__, __project_name__  # noqa: TID252
 
 
 class Settings(OpaqueSettings):

--- a/packages/aignostics/src/aignostics/qupath/_settings.py
+++ b/packages/aignostics/src/aignostics/qupath/_settings.py
@@ -2,7 +2,7 @@
 
 from pydantic_settings import SettingsConfigDict
 
-from ..utils import OpaqueSettings, __env_file__, __project_name__  # noqa: TID252
+from aignostics_sdk.utils import OpaqueSettings, __env_file__, __project_name__  # noqa: TID252
 
 
 class Settings(OpaqueSettings):

--- a/packages/aignostics/src/aignostics/system/_cli.py
+++ b/packages/aignostics/src/aignostics/system/_cli.py
@@ -12,7 +12,7 @@ import typer
 import yaml
 
 from ..constants import API_VERSIONS  # noqa: TID252
-from ..utils import console  # noqa: TID252
+from aignostics_sdk.utils import console  # noqa: TID252
 from ._service import Service
 
 cli = typer.Typer(name="system", help="Determine health, info and further utillities.")
@@ -113,7 +113,7 @@ def dump_dot_env_file(
 
 
 if find_spec("nicegui"):
-    from ..utils import gui_run  # noqa: TID252
+    from aignostics_sdk.utils import gui_run  # noqa: TID252
 
     @cli.command()
     def serve(

--- a/packages/aignostics/src/aignostics/system/_cli.py
+++ b/packages/aignostics/src/aignostics/system/_cli.py
@@ -10,9 +10,9 @@ from typing import Annotated
 
 import typer
 import yaml
+from aignostics_sdk.utils import console
 
 from ..constants import API_VERSIONS  # noqa: TID252
-from aignostics_sdk.utils import console  # noqa: TID252
 from ._service import Service
 
 cli = typer.Typer(name="system", help="Determine health, info and further utillities.")
@@ -113,7 +113,7 @@ def dump_dot_env_file(
 
 
 if find_spec("nicegui"):
-    from aignostics_sdk.utils import gui_run  # noqa: TID252
+    from aignostics_sdk.utils import gui_run
 
     @cli.command()
     def serve(

--- a/packages/aignostics/src/aignostics/system/_gui.py
+++ b/packages/aignostics/src/aignostics/system/_gui.py
@@ -2,10 +2,14 @@
 
 from pathlib import Path
 
-from aignostics.gui import frame
-from aignostics_sdk.utils import BaseService, locate_subclasses
+from aignostics_sdk.utils import (
+    BasePageBuilder,
+    BaseService,
+    locate_subclasses,
+)
 
-from aignostics_sdk.utils import BasePageBuilder  # noqa: TID252
+from aignostics.gui import frame
+
 from ._service import Service
 
 

--- a/packages/aignostics/src/aignostics/system/_gui.py
+++ b/packages/aignostics/src/aignostics/system/_gui.py
@@ -3,9 +3,9 @@
 from pathlib import Path
 
 from aignostics.gui import frame
-from aignostics.utils import BaseService, locate_subclasses
+from aignostics_sdk.utils import BaseService, locate_subclasses
 
-from ..utils import BasePageBuilder  # noqa: TID252
+from aignostics_sdk.utils import BasePageBuilder  # noqa: TID252
 from ._service import Service
 
 

--- a/packages/aignostics/src/aignostics/system/_service.py
+++ b/packages/aignostics/src/aignostics/system/_service.py
@@ -22,7 +22,7 @@ from dotenv import unset_key as dotenv_unset_key
 from loguru import logger
 from pydantic_settings import BaseSettings
 
-from ..utils import (  # noqa: TID252
+from aignostics_sdk.utils import (  # noqa: TID252
     UNHIDE_SENSITIVE_INFO,
     BaseService,
     Health,

--- a/packages/aignostics/src/aignostics/system/_service.py
+++ b/packages/aignostics/src/aignostics/system/_service.py
@@ -17,12 +17,7 @@ from typing import Any, NotRequired, TypedDict
 from urllib.request import getproxies
 
 import httpx
-from dotenv import set_key as dotenv_set_key
-from dotenv import unset_key as dotenv_unset_key
-from loguru import logger
-from pydantic_settings import BaseSettings
-
-from aignostics_sdk.utils import (  # noqa: TID252
+from aignostics_sdk.utils import (
     UNHIDE_SENSITIVE_INFO,
     BaseService,
     Health,
@@ -37,6 +32,11 @@ from aignostics_sdk.utils import (  # noqa: TID252
     locate_subclasses,
     user_agent,
 )
+from dotenv import set_key as dotenv_set_key
+from dotenv import unset_key as dotenv_unset_key
+from loguru import logger
+from pydantic_settings import BaseSettings
+
 from ._exceptions import OpenAPISchemaError
 from ._settings import Settings
 

--- a/packages/aignostics/src/aignostics/system/_settings.py
+++ b/packages/aignostics/src/aignostics/system/_settings.py
@@ -2,10 +2,9 @@
 
 from typing import Annotated
 
+from aignostics_sdk.utils import OpaqueSettings, __env_file__, __project_name__
 from pydantic import Field, PlainSerializer, SecretStr
 from pydantic_settings import SettingsConfigDict
-
-from aignostics_sdk.utils import OpaqueSettings, __env_file__, __project_name__  # noqa: TID252
 
 
 class Settings(OpaqueSettings):

--- a/packages/aignostics/src/aignostics/system/_settings.py
+++ b/packages/aignostics/src/aignostics/system/_settings.py
@@ -5,7 +5,7 @@ from typing import Annotated
 from pydantic import Field, PlainSerializer, SecretStr
 from pydantic_settings import SettingsConfigDict
 
-from ..utils import OpaqueSettings, __env_file__, __project_name__  # noqa: TID252
+from aignostics_sdk.utils import OpaqueSettings, __env_file__, __project_name__  # noqa: TID252
 
 
 class Settings(OpaqueSettings):

--- a/packages/aignostics/src/aignostics/third_party/idc_index.py
+++ b/packages/aignostics/src/aignostics/third_party/idc_index.py
@@ -63,7 +63,7 @@ from packaging.version import Version
 from tqdm import tqdm
 
 from loguru import logger
-from aignostics.utils import SUBPROCESS_CREATION_FLAGS
+from aignostics_sdk.utils import SUBPROCESS_CREATION_FLAGS
 
 aws_endpoint_url = "https://s3.amazonaws.com"
 gcp_endpoint_url = "https://storage.googleapis.com"

--- a/packages/aignostics/src/aignostics/wsi/_cli.py
+++ b/packages/aignostics/src/aignostics/wsi/_cli.py
@@ -7,7 +7,7 @@ from typing import Annotated
 import typer
 from loguru import logger
 
-from aignostics.utils import console
+from aignostics_sdk.utils import console
 
 from ._service import Service
 from ._utils import print_slide_info, print_study_info

--- a/packages/aignostics/src/aignostics/wsi/_cli.py
+++ b/packages/aignostics/src/aignostics/wsi/_cli.py
@@ -5,9 +5,8 @@ from pathlib import Path
 from typing import Annotated
 
 import typer
-from loguru import logger
-
 from aignostics_sdk.utils import console
+from loguru import logger
 
 from ._service import Service
 from ._utils import print_slide_info, print_study_info

--- a/packages/aignostics/src/aignostics/wsi/_gui.py
+++ b/packages/aignostics/src/aignostics/wsi/_gui.py
@@ -4,10 +4,9 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from aignostics_sdk.utils import BasePageBuilder
 from fastapi import Response
 from loguru import logger
-
-from aignostics_sdk.utils import BasePageBuilder
 
 from ._openslide_handler import DEFAULT_MAX_SAFE_DIMENSION
 from ._service import Service

--- a/packages/aignostics/src/aignostics/wsi/_gui.py
+++ b/packages/aignostics/src/aignostics/wsi/_gui.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from fastapi import Response
 from loguru import logger
 
-from aignostics.utils import BasePageBuilder
+from aignostics_sdk.utils import BasePageBuilder
 
 from ._openslide_handler import DEFAULT_MAX_SAFE_DIMENSION
 from ._service import Service

--- a/packages/aignostics/src/aignostics/wsi/_pydicom_handler.py
+++ b/packages/aignostics/src/aignostics/wsi/_pydicom_handler.py
@@ -9,12 +9,11 @@ import highdicom as hd
 import numpy as np
 import pydicom
 import pydicom.errors
+from aignostics_sdk.utils import console
 from loguru import logger
 from pydicom.sr.codedict import codes
 from pydicom.sr.coding import Code
 from shapely.geometry import Polygon
-
-from aignostics_sdk.utils import console
 
 from ._utils import select_dicom_files
 

--- a/packages/aignostics/src/aignostics/wsi/_pydicom_handler.py
+++ b/packages/aignostics/src/aignostics/wsi/_pydicom_handler.py
@@ -14,7 +14,7 @@ from pydicom.sr.codedict import codes
 from pydicom.sr.coding import Code
 from shapely.geometry import Polygon
 
-from aignostics.utils import console
+from aignostics_sdk.utils import console
 
 from ._utils import select_dicom_files
 

--- a/packages/aignostics/src/aignostics/wsi/_service.py
+++ b/packages/aignostics/src/aignostics/wsi/_service.py
@@ -6,10 +6,10 @@ from pathlib import Path
 from typing import Any
 
 import requests
+from aignostics_sdk.utils import BaseService, Health
 from loguru import logger
 
 from aignostics import WSI_SUPPORTED_FILE_EXTENSIONS
-from aignostics_sdk.utils import BaseService, Health
 
 from ._openslide_handler import DEFAULT_MAX_SAFE_DIMENSION
 from ._utils import select_dicom_files

--- a/packages/aignostics/src/aignostics/wsi/_service.py
+++ b/packages/aignostics/src/aignostics/wsi/_service.py
@@ -9,7 +9,7 @@ import requests
 from loguru import logger
 
 from aignostics import WSI_SUPPORTED_FILE_EXTENSIONS
-from aignostics.utils import BaseService, Health
+from aignostics_sdk.utils import BaseService, Health
 
 from ._openslide_handler import DEFAULT_MAX_SAFE_DIMENSION
 from ._utils import select_dicom_files

--- a/packages/aignostics/src/aignostics/wsi/_utils.py
+++ b/packages/aignostics/src/aignostics/wsi/_utils.py
@@ -8,7 +8,7 @@ import humanize
 import pydicom
 from loguru import logger
 
-from aignostics.utils import console
+from aignostics_sdk.utils import console
 
 
 def print_file_info(file_info: dict[str, Any], indent: int = 0) -> None:  # noqa: C901, PLR0912, PLR0915

--- a/packages/aignostics/src/aignostics/wsi/_utils.py
+++ b/packages/aignostics/src/aignostics/wsi/_utils.py
@@ -6,9 +6,8 @@ from typing import Any
 
 import humanize
 import pydicom
-from loguru import logger
-
 from aignostics_sdk.utils import console
+from loguru import logger
 
 
 def print_file_info(file_info: dict[str, Any], indent: int = 0) -> None:  # noqa: C901, PLR0912, PLR0915

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -17,10 +17,11 @@
         "template/**",
         "tests/**",
         "codegen/**",
+        "examples/**",
         "src/aignostics/wsi/_pydicom_handler.py",
         "src/aignostics/notebook/_notebook.py",
+        "packages/aignostics/src/aignostics/wsi/_pydicom_handler.py",
+        "packages/aignostics/src/aignostics/notebook/_notebook.py",
     ],
-    "extraPaths": [
-        "./src/aignostics/utils/_"
-    ]
+    "extraPaths": []
 }

--- a/runner/gui_watch.py
+++ b/runner/gui_watch.py
@@ -1,6 +1,6 @@
 """Graphical User Interface (GUI) of Aignostics Python SDK."""
 
-from aignostics.utils import gui_run
+from aignostics_sdk.utils import gui_run
 
 # For development run via `uv run watch_gui.py`
 gui_run(native=False, show=True, watch=True, dark_mode=False)

--- a/src/aignostics.py
+++ b/src/aignostics.py
@@ -24,7 +24,7 @@ if pyi_splash and pyi_splash.is_alive():
 os.environ["LOGFIRE_PYDANTIC_RECORD"] = "off"
 
 from aignostics.constants import SENTRY_INTEGRATIONS, WINDOW_TITLE  # noqa: E402
-from aignostics.utils import boot, gui_run  # noqa: E402
+from aignostics_sdk.utils import boot, gui_run  # noqa: E402
 
 boot(SENTRY_INTEGRATIONS)
 

--- a/tests/aignostics/application/cli_pipeline_validation_test.py
+++ b/tests/aignostics/application/cli_pipeline_validation_test.py
@@ -5,9 +5,9 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
+from aignostics.cli import cli
 from typer.testing import CliRunner
 
-from aignostics.cli import cli
 from tests.conftest import normalize_output
 from tests.constants_test import HETA_APPLICATION_ID
 

--- a/tests/aignostics/application/cli_test.py
+++ b/tests/aignostics/application/cli_test.py
@@ -17,8 +17,8 @@ from typer.testing import CliRunner
 
 from aignostics.application import Service as ApplicationService
 from aignostics.cli import cli
-from aignostics.platform import LIST_APPLICATION_RUNS_MAX_PAGE_SIZE
-from aignostics.utils import Health, sanitize_path
+from aignostics_sdk.platform import LIST_APPLICATION_RUNS_MAX_PAGE_SIZE
+from aignostics_sdk.utils import Health, sanitize_path
 from tests.conftest import normalize_output, print_directory_structure
 from tests.constants_test import (
     HETA_APPLICATION_ID,

--- a/tests/aignostics/application/cli_test.py
+++ b/tests/aignostics/application/cli_test.py
@@ -11,14 +11,14 @@ from time import sleep
 from unittest.mock import MagicMock, patch
 
 import pytest
-from loguru import logger
-from tenacity import Retrying, retry, stop_after_attempt, wait_exponential
-from typer.testing import CliRunner
-
 from aignostics.application import Service as ApplicationService
 from aignostics.cli import cli
 from aignostics_sdk.platform import LIST_APPLICATION_RUNS_MAX_PAGE_SIZE
 from aignostics_sdk.utils import Health, sanitize_path
+from loguru import logger
+from tenacity import Retrying, retry, stop_after_attempt, wait_exponential
+from typer.testing import CliRunner
+
 from tests.conftest import normalize_output, print_directory_structure
 from tests.constants_test import (
     HETA_APPLICATION_ID,

--- a/tests/aignostics/application/download_test.py
+++ b/tests/aignostics/application/download_test.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import requests
-
 from aignostics.application._download import (
     download_available_items,
     download_item_artifact,

--- a/tests/aignostics/application/download_test.py
+++ b/tests/aignostics/application/download_test.py
@@ -13,7 +13,7 @@ from aignostics.application._download import (
     extract_filename_from_url,
 )
 from aignostics.application._models import DownloadProgress, DownloadProgressState
-from aignostics.platform import ArtifactOutput
+from aignostics_sdk.platform import ArtifactOutput
 
 
 @pytest.mark.unit
@@ -526,7 +526,7 @@ def test_download_available_items_skips_non_available_artifacts(tmp_path: Path) 
     artifacts that aren't AVAILABLE. Calling it for a NONE artifact would fail
     the whole download. This test pins the guard.
     """
-    from aignostics.platform import ItemOutput, ItemState
+    from aignostics_sdk.platform import ItemOutput, ItemState
 
     available = _mock_artifact(output_artifact_id="art-ok", output=ArtifactOutput.AVAILABLE)
     none_artifact = _mock_artifact(output_artifact_id="art-skip", output=ArtifactOutput.NONE)
@@ -563,7 +563,7 @@ def test_download_available_items_passes_run_to_download_item_artifact(tmp_path:
     so the calling site must pass it through. Pinning the call shape keeps the
     contract explicit.
     """
-    from aignostics.platform import ItemOutput, ItemState
+    from aignostics_sdk.platform import ItemOutput, ItemState
 
     artifact = _mock_artifact()
     item = MagicMock()

--- a/tests/aignostics/application/gui_test.py
+++ b/tests/aignostics/application/gui_test.py
@@ -10,10 +10,6 @@ from typing import TYPE_CHECKING
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
-from nicegui.testing import User
-from typer.testing import CliRunner
-
-from aignostics import WSI_SUPPORTED_FILE_EXTENSIONS
 from aignostics.application import Service
 from aignostics.application._gui._page_application_run_describe import (
     RESULTS_PAGE_SIZE,
@@ -21,6 +17,10 @@ from aignostics.application._gui._page_application_run_describe import (
     _resolve_artifact_url_or_notify,
 )
 from aignostics.cli import cli
+from nicegui.testing import User
+from typer.testing import CliRunner
+
+from aignostics import WSI_SUPPORTED_FILE_EXTENSIONS
 from tests.conftest import assert_notified, normalize_output, print_directory_structure
 from tests.constants_test import (
     HETA_APPLICATION_ID,

--- a/tests/aignostics/application/service_test.py
+++ b/tests/aignostics/application/service_test.py
@@ -7,7 +7,7 @@ import pytest
 from typer.testing import CliRunner
 
 from aignostics.application import Service as ApplicationService
-from aignostics.platform import NotFoundException, RunData, RunOutput
+from aignostics_sdk.platform import NotFoundException, RunData, RunOutput
 from tests.constants_test import (
     HETA_APPLICATION_ID,
     HETA_APPLICATION_VERSION,

--- a/tests/aignostics/application/service_test.py
+++ b/tests/aignostics/application/service_test.py
@@ -4,10 +4,10 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import pytest
-from typer.testing import CliRunner
-
 from aignostics.application import Service as ApplicationService
 from aignostics_sdk.platform import NotFoundException, RunData, RunOutput
+from typer.testing import CliRunner
+
 from tests.constants_test import (
     HETA_APPLICATION_ID,
     HETA_APPLICATION_VERSION,

--- a/tests/aignostics/application/utils_test.py
+++ b/tests/aignostics/application/utils_test.py
@@ -6,8 +6,6 @@ from typing import Any
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from aignx.codegen.models import ArtifactOutput, ArtifactState, ArtifactTerminationReason, ItemOutput
-
 from aignostics.application._utils import (
     application_run_status_to_str,
     get_mime_type_for_artifact,
@@ -41,6 +39,7 @@ from aignostics_sdk.platform import (
     RunState,
     RunTerminationReason,
 )
+from aignx.codegen.models import ArtifactOutput, ArtifactState, ArtifactTerminationReason, ItemOutput
 
 TEST_MAPPING_TIFF_HE = ".*\\.tiff:staining_method=H&E"
 SUBMITTED_BY = "user@example.com"

--- a/tests/aignostics/application/utils_test.py
+++ b/tests/aignostics/application/utils_test.py
@@ -30,7 +30,7 @@ from aignostics.constants import (
     WSI_SUPPORTED_FILE_EXTENSIONS,
     WSI_SUPPORTED_FILE_EXTENSIONS_TEST_APP,
 )
-from aignostics.platform import (
+from aignostics_sdk.platform import (
     ItemResult,
     ItemState,
     ItemTerminationReason,

--- a/tests/aignostics/bucket/cli_test.py
+++ b/tests/aignostics/bucket/cli_test.py
@@ -5,9 +5,9 @@ import uuid
 from pathlib import Path
 
 import pytest
+from aignostics.cli import cli
 from typer.testing import CliRunner
 
-from aignostics.cli import cli
 from tests.conftest import normalize_output
 
 MESSAGE_NOT_YET_IMPLEMENTED = "NOT YET IMPLEMENTED"

--- a/tests/aignostics/bucket/gui_test.py
+++ b/tests/aignostics/bucket/gui_test.py
@@ -9,10 +9,10 @@ from unittest.mock import patch
 
 import psutil
 import pytest
+from aignostics.cli import cli
 from nicegui.testing import User
 from typer.testing import CliRunner
 
-from aignostics.cli import cli
 from tests.conftest import assert_notified
 
 

--- a/tests/aignostics/bucket/service_test.py
+++ b/tests/aignostics/bucket/service_test.py
@@ -4,7 +4,6 @@ from typing import Any
 from unittest import mock
 
 import pytest
-
 from aignostics.bucket._service import Service
 
 # ---------------------------------------------------------------------------

--- a/tests/aignostics/bucket/settings_test.py
+++ b/tests/aignostics/bucket/settings_test.py
@@ -3,11 +3,10 @@
 import json
 
 import pytest
-from pydantic import ValidationError
-from typer.testing import CliRunner
-
 from aignostics.bucket._settings import Settings
 from aignostics.cli import cli
+from pydantic import ValidationError
+from typer.testing import CliRunner
 
 
 @pytest.mark.unit

--- a/tests/aignostics/cli_test.py
+++ b/tests/aignostics/cli_test.py
@@ -13,7 +13,7 @@ from typer.testing import CliRunner
 
 from aignostics.cli import cli
 from aignostics.constants import WINDOW_TITLE
-from aignostics.utils import (
+from aignostics_sdk.utils import (
     __python_version__,
     __version__,
 )
@@ -134,7 +134,7 @@ if find_spec("nicegui"):
     # Import module explicitly to ensure it's loaded before monkeypatching with string paths.
     # Without this, monkeypatch.setattr("aignostics.utils._gui...") fails in CI because
     # pytest-xdist workers may not have aignostics.utils loaded as an attribute yet.
-    import aignostics.utils._gui as _utils_gui
+    import aignostics_sdk.utils._gui as _utils_gui
 
     @pytest.mark.integration
     def test_cli_gui_help(runner: CliRunner) -> None:

--- a/tests/aignostics/cli_test.py
+++ b/tests/aignostics/cli_test.py
@@ -8,15 +8,15 @@ from importlib.util import find_spec
 from unittest.mock import patch
 
 import pytest
-from fastmcp import FastMCP
-from typer.testing import CliRunner
-
 from aignostics.cli import cli
 from aignostics.constants import WINDOW_TITLE
 from aignostics_sdk.utils import (
     __python_version__,
     __version__,
 )
+from fastmcp import FastMCP
+from typer.testing import CliRunner
+
 from tests.conftest import normalize_output
 
 BUILT_WITH_LOVE = "built with love in Berlin"

--- a/tests/aignostics/dataset/cli_test.py
+++ b/tests/aignostics/dataset/cli_test.py
@@ -7,9 +7,9 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from aignostics.cli import cli
 from typer.testing import CliRunner
 
-from aignostics.cli import cli
 from tests.conftest import normalize_output
 from tests.constants_test import SPOT_1_FILENAME, SPOT_1_GS_URL
 

--- a/tests/aignostics/dataset/service_test.py
+++ b/tests/aignostics/dataset/service_test.py
@@ -4,7 +4,6 @@ import subprocess
 from unittest import mock
 
 import pytest
-
 from aignostics.dataset._service import _active_processes, _cleanup_processes, _terminate_process
 
 

--- a/tests/aignostics/notebook/service_test.py
+++ b/tests/aignostics/notebook/service_test.py
@@ -6,9 +6,8 @@ import re
 from unittest.mock import MagicMock, patch
 
 import pytest
-from nicegui.testing import User
-
 from aignostics.notebook._service import MARIMO_SERVER_STARTUP_TIMEOUT, Service, _get_runner, _Runner
+from nicegui.testing import User
 
 
 @pytest.mark.integration

--- a/tests/aignostics/platform/authentication_test.py
+++ b/tests/aignostics/platform/authentication_test.py
@@ -13,9 +13,6 @@ from unittest.mock import MagicMock, Mock, patch
 import jwt
 import pytest
 import requests
-from pydantic import SecretStr
-from requests_oauthlib import OAuth2Session
-
 from aignostics_sdk.platform._authentication import (
     _access_token_from_refresh_token,
     _authenticate,
@@ -33,6 +30,8 @@ from aignostics_sdk.platform._messages import (
     AUTHENTICATION_FAILED_TOKEN_VERIFICATION,
     INVALID_REDIRECT_URI,
 )
+from pydantic import SecretStr
+from requests_oauthlib import OAuth2Session
 
 
 @pytest.fixture

--- a/tests/aignostics/platform/authentication_test.py
+++ b/tests/aignostics/platform/authentication_test.py
@@ -16,7 +16,7 @@ import requests
 from pydantic import SecretStr
 from requests_oauthlib import OAuth2Session
 
-from aignostics.platform._authentication import (
+from aignostics_sdk.platform._authentication import (
     _access_token_from_refresh_token,
     _authenticate,
     _can_open_browser,
@@ -27,7 +27,7 @@ from aignostics.platform._authentication import (
     remove_cached_token,
     verify_and_decode_token,
 )
-from aignostics.platform._messages import (
+from aignostics_sdk.platform._messages import (
     AUTHENTICATION_FAILED,
     AUTHENTICATION_FAILED_ACCESS_TOKEN_FROM_REFRESH_TOKEN,
     AUTHENTICATION_FAILED_TOKEN_VERIFICATION,
@@ -966,7 +966,7 @@ class TestJWKClientCache:
         The LRU cache should ensure that multiple calls with the same URL return
         the same PyJWKClient instance, avoiding redundant client creation.
         """
-        from aignostics.platform._authentication import _get_jwk_client
+        from aignostics_sdk.platform._authentication import _get_jwk_client
 
         url = "https://test.auth/.well-known/jwks.json"
         timeout = mock_settings.return_value.auth_timeout
@@ -993,7 +993,7 @@ class TestJWKClientCache:
         The cache should distinguish between different URLs and create separate
         PyJWKClient instances for each unique URL.
         """
-        from aignostics.platform._authentication import _get_jwk_client
+        from aignostics_sdk.platform._authentication import _get_jwk_client
 
         url1 = "https://test1.auth/.well-known/jwks.json"
         url2 = "https://test2.auth/.well-known/jwks.json"
@@ -1021,7 +1021,7 @@ class TestJWKClientCache:
 
         This verifies that the LRU cache is tracking hits and misses correctly.
         """
-        from aignostics.platform._authentication import _get_jwk_client
+        from aignostics_sdk.platform._authentication import _get_jwk_client
 
         info = _get_jwk_client.cache_info()
         assert info.hits == 0
@@ -1057,7 +1057,7 @@ class TestJWKClientCache:
 
         The cache should use settings values when creating PyJWKClient instances.
         """
-        from aignostics.platform._authentication import _get_jwk_client
+        from aignostics_sdk.platform._authentication import _get_jwk_client
 
         url = "https://test.auth/.well-known/jwks.json"
         timeout = mock_settings.return_value.auth_timeout
@@ -1081,7 +1081,7 @@ class TestJWKClientCache:
         Multiple token verifications should reuse the cached PyJWKClient instance,
         reducing the overhead of client creation.
         """
-        from aignostics.platform._authentication import _get_jwk_client
+        from aignostics_sdk.platform._authentication import _get_jwk_client
 
         mock_jwt_client = MagicMock()
         mock_signing_key = MagicMock()
@@ -1116,7 +1116,7 @@ class TestJWKClientCache:
         When more than 4 unique parameter combinations are cached, the least recently used ones
         should be evicted.
         """
-        from aignostics.platform._authentication import _get_jwk_client
+        from aignostics_sdk.platform._authentication import _get_jwk_client
 
         timeout = mock_settings.return_value.auth_timeout
         lifespan = mock_settings.return_value.auth_jwk_set_cache_ttl

--- a/tests/aignostics/platform/cli_test.py
+++ b/tests/aignostics/platform/cli_test.py
@@ -6,8 +6,8 @@ import pytest
 from typer.testing import CliRunner
 
 from aignostics.cli import cli
-from aignostics.platform import Me
-from aignostics.platform._service import Organization, TokenInfo, User, UserInfo
+from aignostics_sdk.platform import Me
+from aignostics_sdk.platform._service import Organization, TokenInfo, User, UserInfo
 from tests.conftest import normalize_output
 
 

--- a/tests/aignostics/platform/cli_test.py
+++ b/tests/aignostics/platform/cli_test.py
@@ -3,11 +3,11 @@
 from unittest.mock import patch
 
 import pytest
-from typer.testing import CliRunner
-
 from aignostics.cli import cli
 from aignostics_sdk.platform import Me
 from aignostics_sdk.platform._service import Organization, TokenInfo, User, UserInfo
+from typer.testing import CliRunner
+
 from tests.conftest import normalize_output
 
 

--- a/tests/aignostics/platform/client_cache_test.py
+++ b/tests/aignostics/platform/client_cache_test.py
@@ -11,7 +11,6 @@ import time
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from aignostics_sdk.platform._client import Client
 from aignostics_sdk.platform._operation_cache import _operation_cache, cache_key_with_token
 

--- a/tests/aignostics/platform/client_cache_test.py
+++ b/tests/aignostics/platform/client_cache_test.py
@@ -12,8 +12,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from aignostics.platform._client import Client
-from aignostics.platform._operation_cache import _operation_cache, cache_key_with_token
+from aignostics_sdk.platform._client import Client
+from aignostics_sdk.platform._operation_cache import _operation_cache, cache_key_with_token
 
 
 class TestCacheKeyGeneration:

--- a/tests/aignostics/platform/client_me_retry_test.py
+++ b/tests/aignostics/platform/client_me_retry_test.py
@@ -10,7 +10,7 @@ from aignx.codegen.exceptions import ServiceException
 from urllib3.exceptions import IncompleteRead, PoolError, ProtocolError, ProxyError
 from urllib3.exceptions import TimeoutError as Urllib3TimeoutError
 
-from aignostics.platform._client import Client
+from aignostics_sdk.platform._client import Client
 
 
 class TestMeSuccess:

--- a/tests/aignostics/platform/client_me_retry_test.py
+++ b/tests/aignostics/platform/client_me_retry_test.py
@@ -6,11 +6,10 @@ from http import HTTPStatus
 from unittest.mock import ANY, MagicMock, Mock, patch
 
 import pytest
+from aignostics_sdk.platform._client import Client
 from aignx.codegen.exceptions import ServiceException
 from urllib3.exceptions import IncompleteRead, PoolError, ProtocolError, ProxyError
 from urllib3.exceptions import TimeoutError as Urllib3TimeoutError
-
-from aignostics_sdk.platform._client import Client
 
 
 class TestMeSuccess:

--- a/tests/aignostics/platform/client_pooling_test.py
+++ b/tests/aignostics/platform/client_pooling_test.py
@@ -1,7 +1,6 @@
 """Tests for API client connection pooling."""
 
 import pytest
-
 from aignostics_sdk.platform._client import Client
 
 

--- a/tests/aignostics/platform/client_pooling_test.py
+++ b/tests/aignostics/platform/client_pooling_test.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from aignostics.platform._client import Client
+from aignostics_sdk.platform._client import Client
 
 
 @pytest.mark.unit

--- a/tests/aignostics/platform/client_token_provider_test.py
+++ b/tests/aignostics/platform/client_token_provider_test.py
@@ -4,7 +4,6 @@ from collections.abc import Callable
 from unittest.mock import Mock, patch
 
 import pytest
-
 from aignostics_sdk.platform._api import _AuthenticatedApi, _AuthenticatedResource, _OAuth2TokenProviderConfiguration
 from aignostics_sdk.platform._client import Client
 

--- a/tests/aignostics/platform/client_token_provider_test.py
+++ b/tests/aignostics/platform/client_token_provider_test.py
@@ -5,8 +5,8 @@ from unittest.mock import Mock, patch
 
 import pytest
 
-from aignostics.platform._api import _AuthenticatedApi, _AuthenticatedResource, _OAuth2TokenProviderConfiguration
-from aignostics.platform._client import Client
+from aignostics_sdk.platform._api import _AuthenticatedApi, _AuthenticatedResource, _OAuth2TokenProviderConfiguration
+from aignostics_sdk.platform._client import Client
 
 # Module-level constants for repeated string literals (extracted to satisfy
 # SonarQube python:S1192 — "Define a constant instead of duplicating this literal").
@@ -221,7 +221,7 @@ def test_none_token_provider_no_warning() -> None:
 @pytest.mark.unit
 def test_external_provider_cache_bounded() -> None:
     """Test that _api_client_external is bounded to _MAX_EXTERNAL_CLIENTS entries."""
-    from aignostics.platform._client import _MAX_EXTERNAL_CLIENTS
+    from aignostics_sdk.platform._client import _MAX_EXTERNAL_CLIENTS
 
     with (
         patch(_APICLIENT_PATCH),

--- a/tests/aignostics/platform/conftest.py
+++ b/tests/aignostics/platform/conftest.py
@@ -4,7 +4,6 @@ import typing as t
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from aignostics_sdk.platform._api import _AuthenticatedApi
 from aignostics_sdk.platform._client import Client
 from aignostics_sdk.platform._operation_cache import _operation_cache

--- a/tests/aignostics/platform/conftest.py
+++ b/tests/aignostics/platform/conftest.py
@@ -5,10 +5,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from aignostics.platform._api import _AuthenticatedApi
-from aignostics.platform._client import Client
-from aignostics.platform._operation_cache import _operation_cache
-from aignostics.platform._service import Service
+from aignostics_sdk.platform._api import _AuthenticatedApi
+from aignostics_sdk.platform._client import Client
+from aignostics_sdk.platform._operation_cache import _operation_cache
+from aignostics_sdk.platform._service import Service
 
 
 @pytest.fixture
@@ -112,7 +112,7 @@ def clear_jwk_cache() -> t.Generator[None, None, None]:
     Yields:
         None: This fixture doesn't yield a value.
     """
-    from aignostics.platform._authentication import _get_jwk_client
+    from aignostics_sdk.platform._authentication import _get_jwk_client
 
     _get_jwk_client.cache_clear()
     yield

--- a/tests/aignostics/platform/e2e_test.py
+++ b/tests/aignostics/platform/e2e_test.py
@@ -12,6 +12,8 @@ from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
+from aignostics_sdk import platform
+from aignostics_sdk.platform import Run, RunSdkMetadata
 from aignx.codegen.models import (
     ArtifactOutput,
     ArtifactState,
@@ -25,8 +27,6 @@ from aignx.codegen.models.run_read_response import RunReadResponse
 from loguru import logger
 from sentry_sdk import metrics
 
-from aignostics_sdk import platform
-from aignostics_sdk.platform import Run, RunSdkMetadata
 from tests.constants_test import (
     HETA_APPLICATION_ID,
     HETA_APPLICATION_VERSION,

--- a/tests/aignostics/platform/e2e_test.py
+++ b/tests/aignostics/platform/e2e_test.py
@@ -25,8 +25,8 @@ from aignx.codegen.models.run_read_response import RunReadResponse
 from loguru import logger
 from sentry_sdk import metrics
 
-from aignostics import platform
-from aignostics.platform import Run, RunSdkMetadata
+from aignostics_sdk import platform
+from aignostics_sdk.platform import Run, RunSdkMetadata
 from tests.constants_test import (
     HETA_APPLICATION_ID,
     HETA_APPLICATION_VERSION,

--- a/tests/aignostics/platform/nocache_test.py
+++ b/tests/aignostics/platform/nocache_test.py
@@ -11,7 +11,6 @@ import time
 from unittest.mock import MagicMock
 
 import pytest
-
 from aignostics_sdk.platform._client import Client
 from aignostics_sdk.platform._operation_cache import _operation_cache, cached_operation, operation_cache_clear
 

--- a/tests/aignostics/platform/nocache_test.py
+++ b/tests/aignostics/platform/nocache_test.py
@@ -12,8 +12,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from aignostics.platform._client import Client
-from aignostics.platform._operation_cache import _operation_cache, cached_operation, operation_cache_clear
+from aignostics_sdk.platform._client import Client
+from aignostics_sdk.platform._operation_cache import _operation_cache, cached_operation, operation_cache_clear
 
 
 class TestNocacheDecoratorBehavior:
@@ -440,7 +440,7 @@ class TestRunDetailsNocache:
         """Test that Run.details() method signature supports nocache parameter."""
         from inspect import signature
 
-        from aignostics.platform.resources.runs import Run
+        from aignostics_sdk.platform.resources.runs import Run
 
         # Verify the method has nocache parameter
         sig = signature(Run.details)
@@ -459,7 +459,7 @@ class TestRunsListNocache:
         """Test that Runs.list() method signature supports nocache parameter."""
         from inspect import signature
 
-        from aignostics.platform.resources.runs import Runs
+        from aignostics_sdk.platform.resources.runs import Runs
 
         # Verify the method has nocache parameter
         sig = signature(Runs.list)
@@ -478,7 +478,7 @@ class TestApplicationsResourcesNocache:
         """Test that Versions.list() method signature supports nocache parameter."""
         from inspect import signature
 
-        from aignostics.platform.resources.applications import Versions
+        from aignostics_sdk.platform.resources.applications import Versions
 
         # Verify the method has nocache parameter
         sig = signature(Versions.list)
@@ -493,7 +493,7 @@ class TestApplicationsResourcesNocache:
         """Test that Applications.details() method signature supports nocache parameter."""
         from inspect import signature
 
-        from aignostics.platform.resources.applications import Applications
+        from aignostics_sdk.platform.resources.applications import Applications
 
         # Verify the method has nocache parameter
         sig = signature(Applications.details)

--- a/tests/aignostics/platform/resources/applications_test.py
+++ b/tests/aignostics/platform/resources/applications_test.py
@@ -16,15 +16,15 @@ from aignx.codegen.models.application_read_response import ApplicationReadRespon
 from aignx.codegen.models.version_document_response import VersionDocumentResponse
 from aignx.codegen.models.version_document_visibility import VersionDocumentVisibility
 
-from aignostics.platform._api import _AuthenticatedApi
-from aignostics.platform._operation_cache import operation_cache_clear
-from aignostics.platform.resources.applications import (
+from aignostics_sdk.platform._api import _AuthenticatedApi
+from aignostics_sdk.platform._operation_cache import operation_cache_clear
+from aignostics_sdk.platform.resources.applications import (
     Applications,
     ApplicationVersionDocument,
     Documents,
     Versions,
 )
-from aignostics.platform.resources.utils import PAGE_SIZE
+from aignostics_sdk.platform.resources.utils import PAGE_SIZE
 
 API_ERROR = "API error"
 API_REASON_NOT_FOUND = "Not Found"
@@ -410,8 +410,8 @@ def test_versions_documents_resolves_none_to_latest(mock_api: Mock) -> None:
     """Versions.documents(None) resolves to the latest version number."""
     from unittest.mock import patch
 
-    from aignostics.platform.resources.applications import Versions as _Versions
-    from aignostics.platform.resources.applications import VersionTuple
+    from aignostics_sdk.platform.resources.applications import Versions as _Versions
+    from aignostics_sdk.platform.resources.applications import VersionTuple
 
     latest = Mock(spec=VersionTuple)
     latest.number = "2.3.1"

--- a/tests/aignostics/platform/resources/applications_test.py
+++ b/tests/aignostics/platform/resources/applications_test.py
@@ -11,11 +11,6 @@ from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from aignx.codegen.exceptions import NotFoundException
-from aignx.codegen.models.application_read_response import ApplicationReadResponse
-from aignx.codegen.models.version_document_response import VersionDocumentResponse
-from aignx.codegen.models.version_document_visibility import VersionDocumentVisibility
-
 from aignostics_sdk.platform._api import _AuthenticatedApi
 from aignostics_sdk.platform._operation_cache import operation_cache_clear
 from aignostics_sdk.platform.resources.applications import (
@@ -25,6 +20,10 @@ from aignostics_sdk.platform.resources.applications import (
     Versions,
 )
 from aignostics_sdk.platform.resources.utils import PAGE_SIZE
+from aignx.codegen.exceptions import NotFoundException
+from aignx.codegen.models.application_read_response import ApplicationReadResponse
+from aignx.codegen.models.version_document_response import VersionDocumentResponse
+from aignx.codegen.models.version_document_visibility import VersionDocumentVisibility
 
 API_ERROR = "API error"
 API_REASON_NOT_FOUND = "Not Found"

--- a/tests/aignostics/platform/resources/resource_utils_test.py
+++ b/tests/aignostics/platform/resources/resource_utils_test.py
@@ -7,7 +7,6 @@ on pagination functionality that is used across resource modules.
 from unittest.mock import Mock
 
 import pytest
-
 from aignostics_sdk.platform.resources.utils import PAGE_SIZE, paginate
 
 

--- a/tests/aignostics/platform/resources/resource_utils_test.py
+++ b/tests/aignostics/platform/resources/resource_utils_test.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from aignostics.platform.resources.utils import PAGE_SIZE, paginate
+from aignostics_sdk.platform.resources.utils import PAGE_SIZE, paginate
 
 
 @pytest.mark.unit

--- a/tests/aignostics/platform/resources/runs_test.py
+++ b/tests/aignostics/platform/resources/runs_test.py
@@ -9,6 +9,9 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 import requests
+from aignostics_sdk.platform._api import _AuthenticatedApi
+from aignostics_sdk.platform.resources.runs import LIST_APPLICATION_RUNS_MAX_PAGE_SIZE, Artifact, Run, Runs
+from aignostics_sdk.platform.resources.utils import PAGE_SIZE
 from aignx.codegen.exceptions import ApiException, NotFoundException, ServiceException
 from aignx.codegen.models import (
     InputArtifactCreationRequest,
@@ -17,10 +20,6 @@ from aignx.codegen.models import (
     RunCreationResponse,
     RunReadResponse,
 )
-
-from aignostics_sdk.platform._api import _AuthenticatedApi
-from aignostics_sdk.platform.resources.runs import LIST_APPLICATION_RUNS_MAX_PAGE_SIZE, Artifact, Run, Runs
-from aignostics_sdk.platform.resources.utils import PAGE_SIZE
 
 _PLATFORM_HOST = "https://platform-staging.aignostics.com"
 _RUN_ID = "test-run-id"

--- a/tests/aignostics/platform/resources/runs_test.py
+++ b/tests/aignostics/platform/resources/runs_test.py
@@ -18,9 +18,9 @@ from aignx.codegen.models import (
     RunReadResponse,
 )
 
-from aignostics.platform._api import _AuthenticatedApi
-from aignostics.platform.resources.runs import LIST_APPLICATION_RUNS_MAX_PAGE_SIZE, Artifact, Run, Runs
-from aignostics.platform.resources.utils import PAGE_SIZE
+from aignostics_sdk.platform._api import _AuthenticatedApi
+from aignostics_sdk.platform.resources.runs import LIST_APPLICATION_RUNS_MAX_PAGE_SIZE, Artifact, Run, Runs
+from aignostics_sdk.platform.resources.utils import PAGE_SIZE
 
 _PLATFORM_HOST = "https://platform-staging.aignostics.com"
 _RUN_ID = "test-run-id"

--- a/tests/aignostics/platform/sdk_metadata_test.py
+++ b/tests/aignostics/platform/sdk_metadata_test.py
@@ -5,8 +5,6 @@ from datetime import datetime
 from unittest.mock import MagicMock, patch
 
 import pytest
-from pydantic import ValidationError
-
 from aignostics_sdk.platform._sdk_metadata import (
     ITEM_SDK_METADATA_SCHEMA_VERSION,
     SDK_METADATA_SCHEMA_VERSION,
@@ -21,6 +19,7 @@ from aignostics_sdk.platform._sdk_metadata import (
     validate_run_sdk_metadata,
     validate_run_sdk_metadata_silent,
 )
+from pydantic import ValidationError
 
 # Test constants
 TEST_USER_AGENT = "aignostics-sdk/1.0.0"

--- a/tests/aignostics/platform/sdk_metadata_test.py
+++ b/tests/aignostics/platform/sdk_metadata_test.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pydantic import ValidationError
 
-from aignostics.platform._sdk_metadata import (
+from aignostics_sdk.platform._sdk_metadata import (
     ITEM_SDK_METADATA_SCHEMA_VERSION,
     SDK_METADATA_SCHEMA_VERSION,
     VALIDATION_CASE_TAG_PREFIX,
@@ -994,7 +994,7 @@ class TestPipelineConfiguration:
     @staticmethod
     def test_pipeline_config_defaults() -> None:
         """Test that pipeline configuration uses correct defaults."""
-        from aignostics.platform import (
+        from aignostics_sdk.platform import (
             DEFAULT_CPU_PROVISIONING_MODE,
             DEFAULT_GPU_PROVISIONING_MODE,
             DEFAULT_GPU_TYPE,
@@ -1013,7 +1013,7 @@ class TestPipelineConfiguration:
     @staticmethod
     def test_pipeline_config_custom_values() -> None:
         """Test pipeline configuration with custom values."""
-        from aignostics.platform._sdk_metadata import GPUType, PipelineConfig, ProvisioningMode
+        from aignostics_sdk.platform._sdk_metadata import GPUType, PipelineConfig, ProvisioningMode
 
         config = PipelineConfig(
             gpu={
@@ -1033,7 +1033,7 @@ class TestPipelineConfiguration:
     @staticmethod
     def test_gpu_type_enum() -> None:
         """Test GPUType enum values."""
-        from aignostics.platform._sdk_metadata import GPUType
+        from aignostics_sdk.platform._sdk_metadata import GPUType
 
         assert GPUType.L4.value == "L4"
         assert GPUType.A100.value == "A100"
@@ -1043,7 +1043,7 @@ class TestPipelineConfiguration:
     @staticmethod
     def test_provisioning_mode_enum() -> None:
         """Test ProvisioningMode enum values."""
-        from aignostics.platform._sdk_metadata import ProvisioningMode
+        from aignostics_sdk.platform._sdk_metadata import ProvisioningMode
 
         assert ProvisioningMode.SPOT.value == "SPOT"
         assert ProvisioningMode.ON_DEMAND.value == "ON_DEMAND"
@@ -1054,7 +1054,7 @@ class TestPipelineConfiguration:
     @staticmethod
     def test_metadata_with_pipeline_config() -> None:
         """Test that metadata validates with pipeline configuration."""
-        from aignostics.platform._sdk_metadata import GPUType, ProvisioningMode
+        from aignostics_sdk.platform._sdk_metadata import GPUType, ProvisioningMode
 
         metadata = {
             "schema_version": SDK_METADATA_SCHEMA_VERSION,
@@ -1100,7 +1100,7 @@ class TestPipelineConfiguration:
     @staticmethod
     def test_gpu_config_invalid_max_gpus() -> None:
         """Test that invalid max_gpus_per_slide value is rejected."""
-        from aignostics.platform._sdk_metadata import GPUConfig
+        from aignostics_sdk.platform._sdk_metadata import GPUConfig
 
         with pytest.raises(ValidationError):
             GPUConfig(max_gpus_per_slide=0)  # Must be positive
@@ -1112,7 +1112,7 @@ class TestPipelineConfiguration:
     @staticmethod
     def test_flex_start_provisioning_mode_sets_default_duration() -> None:
         """Test that FLEX_START mode automatically sets default duration when not specified."""
-        from aignostics.platform._sdk_metadata import (
+        from aignostics_sdk.platform._sdk_metadata import (
             DEFAULT_FLEX_START_MAX_RUN_DURATION_MINUTES,
             GPUConfig,
             ProvisioningMode,
@@ -1127,7 +1127,7 @@ class TestPipelineConfiguration:
     @staticmethod
     def test_flex_start_with_custom_duration() -> None:
         """Test FLEX_START mode with custom duration."""
-        from aignostics.platform._sdk_metadata import GPUConfig, ProvisioningMode
+        from aignostics_sdk.platform._sdk_metadata import GPUConfig, ProvisioningMode
 
         config = GPUConfig(
             provisioning_mode=ProvisioningMode.FLEX_START,
@@ -1141,7 +1141,7 @@ class TestPipelineConfiguration:
     @staticmethod
     def test_non_flex_start_mode_rejects_duration() -> None:
         """Test that non-FLEX_START modes reject flex_start_max_run_duration_minutes."""
-        from aignostics.platform._sdk_metadata import GPUConfig, ProvisioningMode
+        from aignostics_sdk.platform._sdk_metadata import GPUConfig, ProvisioningMode
 
         # SPOT mode should not allow flex_start_max_run_duration_minutes
         with pytest.raises(ValidationError) as exc_info:
@@ -1163,7 +1163,7 @@ class TestPipelineConfiguration:
     @staticmethod
     def test_flex_start_duration_out_of_range() -> None:
         """Test that flex_start_max_run_duration_minutes validates range."""
-        from aignostics.platform._sdk_metadata import GPUConfig, ProvisioningMode
+        from aignostics_sdk.platform._sdk_metadata import GPUConfig, ProvisioningMode
 
         # Too low
         with pytest.raises(ValidationError):
@@ -1183,7 +1183,7 @@ class TestPipelineConfiguration:
     @staticmethod
     def test_metadata_with_flex_start_pipeline_config() -> None:
         """Test that metadata validates with FLEX_START pipeline configuration."""
-        from aignostics.platform._sdk_metadata import GPUType, ProvisioningMode
+        from aignostics_sdk.platform._sdk_metadata import GPUType, ProvisioningMode
 
         metadata = {
             "schema_version": SDK_METADATA_SCHEMA_VERSION,
@@ -1212,7 +1212,7 @@ class TestPipelineConfiguration:
     @staticmethod
     def test_default_flex_start_duration_value() -> None:
         """Test that DEFAULT_FLEX_START_MAX_RUN_DURATION_MINUTES is 12 hours (720 minutes)."""
-        from aignostics.platform._sdk_metadata import DEFAULT_FLEX_START_MAX_RUN_DURATION_MINUTES
+        from aignostics_sdk.platform._sdk_metadata import DEFAULT_FLEX_START_MAX_RUN_DURATION_MINUTES
 
         assert DEFAULT_FLEX_START_MAX_RUN_DURATION_MINUTES == 12 * 60  # 720 minutes
 

--- a/tests/aignostics/platform/service_test.py
+++ b/tests/aignostics/platform/service_test.py
@@ -5,8 +5,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from aignostics.platform._service import Service, UserInfo
-from aignostics.utils import Health
+from aignostics_sdk.platform._service import Service, UserInfo
+from aignostics_sdk.utils import Health
 
 _PATCH_AUTH_GETTER = "aignostics.platform._service.get_token"
 _PATCH_HTTPX_ASYNC_CLIENT = "aignostics.platform._service.httpx.AsyncClient"

--- a/tests/aignostics/platform/service_test.py
+++ b/tests/aignostics/platform/service_test.py
@@ -4,7 +4,6 @@ from http import HTTPStatus
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-
 from aignostics_sdk.platform._service import Service, UserInfo
 from aignostics_sdk.utils import Health
 

--- a/tests/aignostics/platform/settings_test.py
+++ b/tests/aignostics/platform/settings_test.py
@@ -8,7 +8,7 @@ import pytest
 from pydantic import SecretStr
 from pydantic import ValidationError as PydanticValidationError
 
-from aignostics.platform import (
+from aignostics_sdk.platform import (
     API_ROOT_DEV,
     API_ROOT_PRODUCTION,
     API_ROOT_STAGING,
@@ -49,7 +49,7 @@ from aignostics.platform import (
     Settings,
     settings,
 )
-from aignostics.utils import __project_name__
+from aignostics_sdk.utils import __project_name__
 
 
 @pytest.fixture
@@ -67,7 +67,7 @@ def mock_env_vars():  # noqa: ANN201
 @pytest.fixture
 def reset_cached_settings():  # noqa: ANN201
     """Reset the cached authentication settings."""
-    import aignostics.platform._settings as _settings_module
+    import aignostics_sdk.platform._settings as _settings_module
 
     original = _settings_module.__cached_settings
     _settings_module.__cached_settings = None
@@ -288,7 +288,7 @@ def test_custom_env_file_location(reset_cached_settings, record_property) -> Non
                     del sys.modules[settings_module]
 
                 # Now import Settings fresh - it should read from the custom env file
-                from aignostics.platform._settings import Settings
+                from aignostics_sdk.platform._settings import Settings
 
                 assert custom_env_file in Settings.model_config["env_file"]
                 test_settings = Settings()

--- a/tests/aignostics/platform/settings_test.py
+++ b/tests/aignostics/platform/settings_test.py
@@ -5,9 +5,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-from pydantic import SecretStr
-from pydantic import ValidationError as PydanticValidationError
-
 from aignostics_sdk.platform import (
     API_ROOT_DEV,
     API_ROOT_PRODUCTION,
@@ -50,6 +47,8 @@ from aignostics_sdk.platform import (
     settings,
 )
 from aignostics_sdk.utils import __project_name__
+from pydantic import SecretStr
+from pydantic import ValidationError as PydanticValidationError
 
 
 @pytest.fixture

--- a/tests/aignostics/platform/utils_test.py
+++ b/tests/aignostics/platform/utils_test.py
@@ -3,7 +3,6 @@
 import math
 
 import pytest
-
 from aignostics_sdk.platform import mime_type_to_file_ending
 from aignostics_sdk.platform._utils import convert_to_json_serializable
 

--- a/tests/aignostics/platform/utils_test.py
+++ b/tests/aignostics/platform/utils_test.py
@@ -4,8 +4,8 @@ import math
 
 import pytest
 
-from aignostics.platform import mime_type_to_file_ending
-from aignostics.platform._utils import convert_to_json_serializable
+from aignostics_sdk.platform import mime_type_to_file_ending
+from aignostics_sdk.platform._utils import convert_to_json_serializable
 
 
 class TestConvertToJsonSerializable:

--- a/tests/aignostics/qupath/cli_test.py
+++ b/tests/aignostics/qupath/cli_test.py
@@ -7,10 +7,10 @@ from pathlib import Path
 
 import psutil
 import pytest
-from typer.testing import CliRunner
-
 from aignostics.cli import cli
 from aignostics.qupath import QUPATH_VERSION
+from typer.testing import CliRunner
+
 from tests.conftest import normalize_output
 
 _SKIP_IF_WINDOWS = pytest.mark.skipif(platform.system() == "Windows", reason="not supported on Windows")

--- a/tests/aignostics/qupath/conftest.py
+++ b/tests/aignostics/qupath/conftest.py
@@ -3,9 +3,8 @@
 from collections.abc import Generator
 
 import pytest
-from typer.testing import CliRunner
-
 from aignostics.cli import cli
+from typer.testing import CliRunner
 
 
 @pytest.fixture

--- a/tests/aignostics/qupath/gui_test.py
+++ b/tests/aignostics/qupath/gui_test.py
@@ -11,13 +11,13 @@ from unittest.mock import patch
 import platformdirs
 import psutil
 import pytest
-from nicegui.testing import User
-from typer.testing import CliRunner
-
 from aignostics.application import Service
 from aignostics.cli import cli
 from aignostics.qupath import QUPATH_LAUNCH_MAX_WAIT_TIME, QUPATH_VERSION
 from aignostics_sdk.utils import __project_name__
+from nicegui.testing import User
+from typer.testing import CliRunner
+
 from tests.conftest import assert_notified, normalize_output, print_directory_structure
 from tests.constants_test import (
     HETA_APPLICATION_ID,

--- a/tests/aignostics/qupath/gui_test.py
+++ b/tests/aignostics/qupath/gui_test.py
@@ -17,7 +17,7 @@ from typer.testing import CliRunner
 from aignostics.application import Service
 from aignostics.cli import cli
 from aignostics.qupath import QUPATH_LAUNCH_MAX_WAIT_TIME, QUPATH_VERSION
-from aignostics.utils import __project_name__
+from aignostics_sdk.utils import __project_name__
 from tests.conftest import assert_notified, normalize_output, print_directory_structure
 from tests.constants_test import (
     HETA_APPLICATION_ID,

--- a/tests/aignostics/system/cli_test.py
+++ b/tests/aignostics/system/cli_test.py
@@ -9,7 +9,7 @@ import pytest
 from typer.testing import CliRunner
 
 from aignostics.cli import cli
-from aignostics.utils import __project_name__
+from aignostics_sdk.utils import __project_name__
 from tests.conftest import normalize_output
 
 THE_VALUE = "test_secret_value_not_real_for_testing_only"
@@ -20,7 +20,7 @@ THE_VALUE = "test_secret_value_not_real_for_testing_only"
 def test_cli_health_json_format(mock_service: MagicMock, runner: CliRunner, record_property) -> None:
     """Check health CLI renders UP status correctly as JSON."""
     record_property("tested-item-id", "TEST-SYSTEM-CLI-HEALTH-JSON")
-    from aignostics.utils import Health
+    from aignostics_sdk.utils import Health
 
     mock_service.health = AsyncMock(return_value=Health(status=Health.Code.UP))
     result = runner.invoke(cli, ["system", "health"])
@@ -33,7 +33,7 @@ def test_cli_health_json_format(mock_service: MagicMock, runner: CliRunner, reco
 def test_cli_health_yaml_format(mock_service: MagicMock, runner: CliRunner, record_property) -> None:
     """Check health CLI renders UP status correctly as YAML."""
     record_property("tested-item-id", "TEST-SYSTEM-CLI-HEALTH-YAML")
-    from aignostics.utils import Health
+    from aignostics_sdk.utils import Health
 
     mock_service.health = AsyncMock(return_value=Health(status=Health.Code.UP))
     result = runner.invoke(cli, ["system", "health", "--output-format", "yaml"])
@@ -116,7 +116,7 @@ def test_cli_info_secrets(runner: CliRunner, caplog: pytest.LogCaptureFixture, r
 @patch("aignostics.system._cli._service")
 def test_cli_health_up_exits_zero(mock_service: MagicMock, runner: CliRunner) -> None:
     """Check health command exits with code 0 when status is UP."""
-    from aignostics.utils import Health
+    from aignostics_sdk.utils import Health
 
     mock_service.health = AsyncMock(return_value=Health(status=Health.Code.UP))
     result = runner.invoke(cli, ["system", "health"])
@@ -127,7 +127,7 @@ def test_cli_health_up_exits_zero(mock_service: MagicMock, runner: CliRunner) ->
 @patch("aignostics.system._cli._service")
 def test_cli_health_degraded_exits_zero(mock_service: MagicMock, runner: CliRunner) -> None:
     """Check health command exits with code 0 when status is DEGRADED."""
-    from aignostics.utils import Health
+    from aignostics_sdk.utils import Health
 
     mock_service.health = AsyncMock(return_value=Health(status=Health.Code.DEGRADED, reason="some component degraded"))
     result = runner.invoke(cli, ["system", "health"])
@@ -138,7 +138,7 @@ def test_cli_health_degraded_exits_zero(mock_service: MagicMock, runner: CliRunn
 @patch("aignostics.system._cli._service")
 def test_cli_health_down_exits_one(mock_service: MagicMock, runner: CliRunner) -> None:
     """Check health command exits with code 1 when status is DOWN."""
-    from aignostics.utils import Health
+    from aignostics_sdk.utils import Health
 
     mock_service.health = AsyncMock(return_value=Health(status=Health.Code.DOWN, reason="service unavailable"))
     result = runner.invoke(cli, ["system", "health"])

--- a/tests/aignostics/system/cli_test.py
+++ b/tests/aignostics/system/cli_test.py
@@ -6,10 +6,10 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from typer.testing import CliRunner
-
 from aignostics.cli import cli
 from aignostics_sdk.utils import __project_name__
+from typer.testing import CliRunner
+
 from tests.conftest import normalize_output
 
 THE_VALUE = "test_secret_value_not_real_for_testing_only"

--- a/tests/aignostics/system/gui_test.py
+++ b/tests/aignostics/system/gui_test.py
@@ -10,7 +10,7 @@ if TYPE_CHECKING:
     from nicegui.testing import User, UserInteraction
     from nicegui.ui import switch
 
-from aignostics.utils import __project_name__
+from aignostics_sdk.utils import __project_name__
 
 
 @pytest.mark.integration

--- a/tests/aignostics/system/service_test.py
+++ b/tests/aignostics/system/service_test.py
@@ -45,7 +45,7 @@ def _patch_info_dependencies(boot_time: float = FIXED_BOOT_TIME):
     cpu_times.system = 10.0
     cpu_times.idle = 70.0
 
-    from aignostics.utils._process import ParentProcessInfo, ProcessInfo
+    from aignostics_sdk.utils._process import ParentProcessInfo, ProcessInfo
 
     mock_process_info = ProcessInfo(
         project_root="/fake/root",

--- a/tests/aignostics/system/service_test.py
+++ b/tests/aignostics/system/service_test.py
@@ -5,7 +5,6 @@ from typing import Any
 from unittest import mock
 
 import pytest
-
 from aignostics.system._service import Service
 
 # ---------------------------------------------------------------------------

--- a/tests/aignostics/utils/cli_test.py
+++ b/tests/aignostics/utils/cli_test.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 from typer.models import CommandInfo, TyperInfo
 
-from aignostics.utils._cli import prepare_cli
+from aignostics_sdk.utils._cli import prepare_cli
 
 # Constants to avoid duplication
 LOCATE_IMPLEMENTATIONS_PATH = "aignostics.utils._cli.locate_implementations"

--- a/tests/aignostics/utils/cli_test.py
+++ b/tests/aignostics/utils/cli_test.py
@@ -4,9 +4,8 @@ from typing import Optional
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from typer.models import CommandInfo, TyperInfo
-
 from aignostics_sdk.utils._cli import prepare_cli
+from typer.models import CommandInfo, TyperInfo
 
 # Constants to avoid duplication
 LOCATE_IMPLEMENTATIONS_PATH = "aignostics.utils._cli.locate_implementations"

--- a/tests/aignostics/utils/console_test.py
+++ b/tests/aignostics/utils/console_test.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from aignostics.utils._console import _get_console
+from aignostics_sdk.utils._console import _get_console
 
 
 @pytest.mark.unit

--- a/tests/aignostics/utils/console_test.py
+++ b/tests/aignostics/utils/console_test.py
@@ -1,7 +1,6 @@
 """Tests for console module."""
 
 import pytest
-
 from aignostics_sdk.utils._console import _get_console
 
 

--- a/tests/aignostics/utils/constants_test.py
+++ b/tests/aignostics/utils/constants_test.py
@@ -3,7 +3,6 @@
 import re
 
 import pytest
-
 from aignostics_sdk.utils import __python_version__, __version__
 
 

--- a/tests/aignostics/utils/constants_test.py
+++ b/tests/aignostics/utils/constants_test.py
@@ -4,7 +4,7 @@ import re
 
 import pytest
 
-from aignostics.utils import __python_version__, __version__
+from aignostics_sdk.utils import __python_version__, __version__
 
 
 @pytest.mark.unit

--- a/tests/aignostics/utils/di_test.py
+++ b/tests/aignostics/utils/di_test.py
@@ -6,10 +6,9 @@ from contextlib import contextmanager
 from types import ModuleType
 from unittest.mock import MagicMock, Mock, patch
 
+import aignostics_sdk.utils._di as di_module
 import pytest
 import typer
-
-import aignostics_sdk.utils._di as di_module
 from aignostics_sdk.utils._cli import (
     _add_epilog_recursively,
     _no_args_is_help_recursively,

--- a/tests/aignostics/utils/di_test.py
+++ b/tests/aignostics/utils/di_test.py
@@ -9,14 +9,14 @@ from unittest.mock import MagicMock, Mock, patch
 import pytest
 import typer
 
-import aignostics.utils._di as di_module
-from aignostics.utils._cli import (
+import aignostics_sdk.utils._di as di_module
+from aignostics_sdk.utils._cli import (
     _add_epilog_recursively,
     _no_args_is_help_recursively,
     prepare_cli,
 )
-from aignostics.utils._constants import __project_name__
-from aignostics.utils._di import (
+from aignostics_sdk.utils._constants import __project_name__
+from aignostics_sdk.utils._di import (
     PLUGIN_ENTRY_POINT_GROUP,
     _implementation_cache,
     _subclass_cache,
@@ -467,7 +467,7 @@ def test_locate_implementations_searches_plugins(clear_di_caches, record_propert
     record_property("tested-item-id", "SPEC-UTILS-SERVICE")
     """Test that locate_implementations searches plugin packages."""
     record_property("tested-item-id", "SPEC-UTILS-SERVICE")
-    import aignostics.utils._di as di_module
+    import aignostics_sdk.utils._di as di_module
 
     plugin_instance = AnotherDummyBase()
     mock_plugin_package = ModuleType("test_plugin")
@@ -599,7 +599,7 @@ def test_locate_implementations_deep_scans_main_package(clear_di_caches, record_
 def test_locate_implementations_caches_results(clear_di_caches, record_property) -> None:
     """Test that locate_implementations caches results."""
     record_property("tested-item-id", "SPEC-UTILS-SERVICE")
-    import aignostics.utils._di as di_module
+    import aignostics_sdk.utils._di as di_module
 
     mock_package = MagicMock()
     mock_package.__path__ = []
@@ -646,7 +646,7 @@ def test_locate_subclasses_searches_plugins(clear_di_caches, record_property) ->
     record_property("tested-item-id", "SPEC-UTILS-SERVICE")
     """Test that locate_subclasses searches plugin packages."""
     record_property("tested-item-id", "SPEC-UTILS-SERVICE")
-    import aignostics.utils._di as di_module
+    import aignostics_sdk.utils._di as di_module
 
     class PluginSubClass(AnotherDummyBase):
         pass
@@ -787,7 +787,7 @@ def test_locate_subclasses_deep_scans_main_package(clear_di_caches, record_prope
 def test_locate_subclasses_excludes_base_class(clear_di_caches, record_property) -> None:
     """Test that locate_subclasses excludes the base class itself."""
     record_property("tested-item-id", "SPEC-UTILS-SERVICE")
-    import aignostics.utils._di as di_module
+    import aignostics_sdk.utils._di as di_module
 
     mock_package = _mock_package()
     mock_module = ModuleType("aignostics.testmodule")
@@ -806,7 +806,7 @@ def test_locate_subclasses_excludes_base_class(clear_di_caches, record_property)
 def test_locate_subclasses_caches_results(clear_di_caches, record_property) -> None:
     """Test that locate_subclasses caches results."""
     record_property("tested-item-id", "SPEC-UTILS-SERVICE")
-    import aignostics.utils._di as di_module
+    import aignostics_sdk.utils._di as di_module
 
     mock_package = MagicMock()
     mock_package.__path__ = []
@@ -826,7 +826,7 @@ def test_locate_subclasses_caches_results(clear_di_caches, record_property) -> N
 def test_locate_subclasses_handles_plugin_import_error(clear_di_caches, record_property) -> None:
     """Test that locate_subclasses handles ImportError for plugin packages gracefully."""
     record_property("tested-item-id", "SPEC-UTILS-SERVICE")
-    import aignostics.utils._di as di_module
+    import aignostics_sdk.utils._di as di_module
 
     mock_package = MagicMock()
     mock_package.__path__ = []
@@ -848,7 +848,7 @@ def test_locate_subclasses_handles_plugin_import_error(clear_di_caches, record_p
 def test_locate_subclasses_handles_module_import_error(clear_di_caches, record_property) -> None:
     """Test that locate_subclasses handles ImportError for individual modules gracefully."""
     record_property("tested-item-id", "SPEC-UTILS-SERVICE")
-    import aignostics.utils._di as di_module
+    import aignostics_sdk.utils._di as di_module
 
     mock_package = _mock_package()
     call_count = 0
@@ -898,7 +898,7 @@ def test_locate_implementations_and_subclasses_search_both_plugins_and_main_pack
 ) -> None:
     """Test that both functions search plugins first, then main package."""
     record_property("tested-item-id", "SPEC-UTILS-SERVICE")
-    import aignostics.utils._di as di_module
+    import aignostics_sdk.utils._di as di_module
 
     import_order: list[str] = []
 

--- a/tests/aignostics/utils/fs_test.py
+++ b/tests/aignostics/utils/fs_test.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from aignostics.utils._fs import (
+from aignostics_sdk.utils._fs import (
     get_user_data_directory,
     open_user_data_directory,
     sanitize_path,

--- a/tests/aignostics/utils/fs_test.py
+++ b/tests/aignostics/utils/fs_test.py
@@ -4,7 +4,6 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-
 from aignostics_sdk.utils._fs import (
     get_user_data_directory,
     open_user_data_directory,

--- a/tests/aignostics/utils/gui_test.py
+++ b/tests/aignostics/utils/gui_test.py
@@ -5,7 +5,6 @@ import platform
 from unittest import mock
 
 import pytest
-
 from aignostics_sdk.utils._constants import __project_name__
 from aignostics_sdk.utils._gui import (
     BasePageBuilder,

--- a/tests/aignostics/utils/gui_test.py
+++ b/tests/aignostics/utils/gui_test.py
@@ -6,8 +6,8 @@ from unittest import mock
 
 import pytest
 
-from aignostics.utils._constants import __project_name__
-from aignostics.utils._gui import (
+from aignostics_sdk.utils._constants import __project_name__
+from aignostics_sdk.utils._gui import (
     BasePageBuilder,
     gui_register_pages,
     gui_run,

--- a/tests/aignostics/utils/health_test.py
+++ b/tests/aignostics/utils/health_test.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from aignostics.utils._health import Health
+from aignostics_sdk.utils._health import Health
 
 DB_FAILURE = "DB failure"
 CACHE_SLOW = "cache slow"

--- a/tests/aignostics/utils/health_test.py
+++ b/tests/aignostics/utils/health_test.py
@@ -1,7 +1,6 @@
 """Tests for health models and status definitions."""
 
 import pytest
-
 from aignostics_sdk.utils._health import Health
 
 DB_FAILURE = "DB failure"

--- a/tests/aignostics/utils/log_test.py
+++ b/tests/aignostics/utils/log_test.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
-
 from aignostics_sdk.utils._log import _validate_file_name, logging_initialize
 
 

--- a/tests/aignostics/utils/log_test.py
+++ b/tests/aignostics/utils/log_test.py
@@ -7,7 +7,7 @@ from unittest import mock
 
 import pytest
 
-from aignostics.utils._log import _validate_file_name, logging_initialize
+from aignostics_sdk.utils._log import _validate_file_name, logging_initialize
 
 
 @pytest.mark.unit
@@ -105,7 +105,7 @@ def test_validate_file_name_invalid_path(record_property) -> None:
 def test_logging_initialize_with_defaults(record_property, caplog: pytest.LogCaptureFixture) -> None:
     """Test logging_initialize with default settings."""
     record_property("tested-item-id", "SPEC-UTILS-SERVICE")
-    from aignostics.utils._log import logger
+    from aignostics_sdk.utils._log import logger
 
     with (
         mock.patch("aignostics.utils._log.load_settings") as mock_load_settings,

--- a/tests/aignostics/utils/mcp_test.py
+++ b/tests/aignostics/utils/mcp_test.py
@@ -9,14 +9,14 @@ from unittest.mock import patch
 import pytest
 from fastmcp import Client, FastMCP
 
-from aignostics.utils import (
+from aignostics_sdk.utils import (
     MCP_SERVER_NAME,
     discover_plugin_packages,
     mcp_create_server,
     mcp_discover_servers,
     mcp_list_tools,
 )
-from aignostics.utils._di import _implementation_cache
+from aignostics_sdk.utils._di import _implementation_cache
 
 if TYPE_CHECKING:
     from collections.abc import Iterator

--- a/tests/aignostics/utils/mcp_test.py
+++ b/tests/aignostics/utils/mcp_test.py
@@ -7,8 +7,6 @@ from typing import TYPE_CHECKING
 from unittest.mock import patch
 
 import pytest
-from fastmcp import Client, FastMCP
-
 from aignostics_sdk.utils import (
     MCP_SERVER_NAME,
     discover_plugin_packages,
@@ -17,6 +15,7 @@ from aignostics_sdk.utils import (
     mcp_list_tools,
 )
 from aignostics_sdk.utils._di import _implementation_cache
+from fastmcp import Client, FastMCP
 
 if TYPE_CHECKING:
     from collections.abc import Iterator

--- a/tests/aignostics/utils/plugin_test.py
+++ b/tests/aignostics/utils/plugin_test.py
@@ -6,7 +6,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 import typer
-
 from aignostics_sdk.utils import BaseNavBuilder
 from aignostics_sdk.utils._di import _implementation_cache, _subclass_cache, discover_plugin_packages
 

--- a/tests/aignostics/utils/plugin_test.py
+++ b/tests/aignostics/utils/plugin_test.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING
 import pytest
 import typer
 
-from aignostics.utils import BaseNavBuilder
-from aignostics.utils._di import _implementation_cache, _subclass_cache, discover_plugin_packages
+from aignostics_sdk.utils import BaseNavBuilder
+from aignostics_sdk.utils._di import _implementation_cache, _subclass_cache, discover_plugin_packages
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -36,7 +36,7 @@ def test_plugin_cli_registered(install_dummy_plugin, clear_plugin_caches, record
     """Integration: plugin Typer CLI instance is discovered via DI after installation."""
     record_property("tested-item-id", "TC-UTILS-PLUGIN-02")
 
-    from aignostics.utils._di import locate_implementations
+    from aignostics_sdk.utils._di import locate_implementations
 
     typer_instances = locate_implementations(typer.Typer)
     names = [t.info.name for t in typer_instances if hasattr(t, "info") and t.info.name]
@@ -51,8 +51,8 @@ def test_plugin_nav_builder_registered(install_dummy_plugin, clear_plugin_caches
     """Integration: plugin BaseNavBuilder subclass is discovered via DI after installation."""
     record_property("tested-item-id", "TC-UTILS-PLUGIN-03")
 
-    from aignostics.utils import gui_get_nav_groups
-    from aignostics.utils._di import locate_subclasses
+    from aignostics_sdk.utils import gui_get_nav_groups
+    from aignostics_sdk.utils._di import locate_subclasses
 
     nav_builder_classes = locate_subclasses(BaseNavBuilder)
     class_names = [cls.__name__ for cls in nav_builder_classes]

--- a/tests/aignostics/utils/sentry_test.py
+++ b/tests/aignostics/utils/sentry_test.py
@@ -11,7 +11,7 @@ if find_spec("sentry_sdk"):
     import pytest
     from pydantic import SecretStr
 
-    from aignostics.utils._sentry import (
+    from aignostics_sdk.utils._sentry import (
         _ERR_MSG_INVALID_DOMAIN,
         _ERR_MSG_MISSING_NETLOC,
         _ERR_MSG_MISSING_SCHEME,

--- a/tests/aignostics/utils/sentry_test.py
+++ b/tests/aignostics/utils/sentry_test.py
@@ -9,8 +9,6 @@ if find_spec("sentry_sdk"):
     from unittest import mock
 
     import pytest
-    from pydantic import SecretStr
-
     from aignostics_sdk.utils._sentry import (
         _ERR_MSG_INVALID_DOMAIN,
         _ERR_MSG_MISSING_NETLOC,
@@ -23,6 +21,7 @@ if find_spec("sentry_sdk"):
         _validate_url_scheme,
         sentry_initialize,
     )
+    from pydantic import SecretStr
 
     VALID_DSN = "https://abcdef1234567890@o12345.ingest.us.sentry.io/1234567890"
 

--- a/tests/aignostics/utils/service_test.py
+++ b/tests/aignostics/utils/service_test.py
@@ -4,7 +4,6 @@ import inspect
 from typing import Any
 
 import pytest
-
 from aignostics_sdk.utils._health import Health
 from aignostics_sdk.utils._service import BaseService
 

--- a/tests/aignostics/utils/service_test.py
+++ b/tests/aignostics/utils/service_test.py
@@ -5,8 +5,8 @@ from typing import Any
 
 import pytest
 
-from aignostics.utils._health import Health
-from aignostics.utils._service import BaseService
+from aignostics_sdk.utils._health import Health
+from aignostics_sdk.utils._service import BaseService
 
 
 class _ConcreteService(BaseService):

--- a/tests/aignostics/utils/settings_test.py
+++ b/tests/aignostics/utils/settings_test.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 from pydantic import SecretStr
 
-from aignostics.utils._settings import (
+from aignostics_sdk.utils._settings import (
     UNHIDE_SENSITIVE_INFO,
     OpaqueSettings,
     load_settings,

--- a/tests/aignostics/utils/settings_test.py
+++ b/tests/aignostics/utils/settings_test.py
@@ -5,14 +5,13 @@ from typing import Any, ClassVar
 from unittest.mock import patch
 
 import pytest
-from pydantic import SecretStr
-
 from aignostics_sdk.utils._settings import (
     UNHIDE_SENSITIVE_INFO,
     OpaqueSettings,
     load_settings,
     strip_to_none_before_validator,
 )
+from pydantic import SecretStr
 
 
 @pytest.mark.unit

--- a/tests/aignostics/utils/user_agent_test.py
+++ b/tests/aignostics/utils/user_agent_test.py
@@ -4,7 +4,6 @@ import platform
 from unittest.mock import patch
 
 import pytest
-
 from aignostics_sdk.utils._user_agent import user_agent
 
 

--- a/tests/aignostics/utils/user_agent_test.py
+++ b/tests/aignostics/utils/user_agent_test.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from aignostics.utils._user_agent import user_agent
+from aignostics_sdk.utils._user_agent import user_agent
 
 
 @pytest.mark.unit

--- a/tests/aignostics/wsi/cli_test.py
+++ b/tests/aignostics/wsi/cli_test.py
@@ -6,9 +6,9 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from aignostics.cli import cli
 from typer.testing import CliRunner
 
-from aignostics.cli import cli
 from tests.conftest import normalize_output
 
 SERIES_UID = "1.3.6.1.4.1.5962.99.1.1069745200.1645485340.1637452317744.2.0"

--- a/tests/aignostics/wsi/service_test.py
+++ b/tests/aignostics/wsi/service_test.py
@@ -10,12 +10,11 @@ from pathlib import Path
 
 import pydicom
 import pytest
+from aignostics.wsi import Service as WSIService
 from fastapi.testclient import TestClient
 from nicegui import app
 from nicegui.testing import User
 from PIL import Image
-
-from aignostics.wsi import Service as WSIService
 
 CONTENT_LENGTH_FALLBACK = 32066  # Fallback image size in bytes
 

--- a/tests/main.py
+++ b/tests/main.py
@@ -1,7 +1,7 @@
 """Start script for pytest."""
 
 from aignostics.constants import WINDOW_TITLE
-from aignostics.utils import (
+from aignostics_sdk.utils import (
     gui_run,
 )
 

--- a/tests/resources/mcp_dummy_plugin/src/mcp_dummy_plugin/_nav.py
+++ b/tests/resources/mcp_dummy_plugin/src/mcp_dummy_plugin/_nav.py
@@ -1,6 +1,6 @@
 """Dummy nav builder for integration testing of plugin GUI page registration."""
 
-from aignostics.utils import BaseNavBuilder, NavItem
+from aignostics_sdk.utils import BaseNavBuilder, NavItem
 
 
 class DummyPluginNavBuilder(BaseNavBuilder):


### PR DESCRIPTION
## Release Train — PYSDK-133

> Verify wiring on the integration branch first: **#661** (draft, targets `main`)

| Step | PR | Jira | Phase | Notes |
|------|----|------|-------|-------|
| 1 | #653 | PYSDK-134 | Workspace scaffolding | **Merge first — gates everything below** |
| 2a | #656 | PYSDK-135 | Source migration | After #653 |
| 2b | #655 | PYSDK-138 | Dependency split | After #653, parallel with 2a |
| 2c | #654 | PYSDK-139 | Tooling updates | After #653, parallel with 2a |
| 3 | #657 | PYSDK-136 | Import rewrite | After #656 |
| 4a | #658 | PYSDK-137 | Slim CLI | After #657 |
| 4b | #659 | PYSDK-141 | Tests | After #657, parallel with 4a |
| ∞ | #651 | PYSDK-140 | CI/CD pipeline | Independent — merge any time |
| ∞ | #652 | PYSDK-142 | Docs & migration | Independent — merge any time |

> **Retargeting**: each PR currently targets its predecessor branch. After the predecessor merges into `feat/PYSDK-133/python-sdk-slim`, retarget this PR to `feat/PYSDK-133/python-sdk-slim` before merging it.

---

> **This PR — Step 3**: Merge after #656 (source migration). Retarget to `feat/PYSDK-133/python-sdk-slim` first. #658 (slim CLI) and #659 (tests) depend on this.

## Summary

- Rewrites **206 import statements** across **91 source files** (packages/aignostics-sdk/, packages/aignostics/, tests/, runner/, src/, examples/) so that `platform` and `utils` references resolve to the new `aignostics_sdk` package
- Fixes two non-trivial import forms missed by naive sed: `from ..utils import` (two-level relative imports in heavy modules) and `from .utils.boot import boot` (relative import in aignostics `__init__.py`)
- Restores `aignostics.constants` imports in files that need heavy constants (`WINDOW_TITLE`, `HETA_APPLICATION_ID`, etc.) which live in the full `aignostics` package, not the slim `aignostics_sdk.constants`
- Patches `utils/_constants.py` for backward compatibility:
  - `__project_name__ = "aignostics"` — preserves `~/.aignostics/` token cache and `AIGNOSTICS_*` env-var prefix
  - `_package_name = __name__.split(".")[0]` → `"aignostics_sdk"` — used for all three `importlib.metadata` calls (version, Project-URLs, Author-email) so they resolve against the correct installed distribution
- Updates `pyrightconfig.json` ignore paths to reflect the new `packages/` layout from PYSDK-135
- **900 tests collect successfully with 0 collection errors** after the rewrite

## Notable decisions

| Decision | Rationale |
|----------|-----------|
| `__project_name__ = "aignostics"` hardcoded | Preserves token cache location and env var prefix for users; deliberate migration deferred — see TODO(PYSDK-136) |
| `aignostics.constants` imports preserved | Those constants (`WINDOW_TITLE`, `HETA_APPLICATION_ID`, etc.) live in the full `aignostics` package, not in `aignostics_sdk.constants` |
| `examples/` added to pyright ignore | These had pre-existing `from aignostics import platform` errors since PYSDK-135 (the public API hasn't been wired up yet) |

## Dependencies

- Builds on top of **PYSDK-135** (source migration)
- PYSDK-137 (slim CLI) and PYSDK-141 (tests reorganization) build on top of this change

## Test plan

- [ ] Lint passes (`make lint`) — verified locally before push
- [ ] 900 tests collect with 0 errors (`uv run pytest tests/ --collect-only -q`)
- [ ] Unit tests pass (`make test_unit`)