### PR TITLE
feat(cli): add aignostics-sdk slim CLI entry point [PYSDK-137]

### DIFF
--- a/packages/aignostics-sdk/src/aignostics_sdk/cli.py
+++ b/packages/aignostics-sdk/src/aignostics_sdk/cli.py
@@ -1,0 +1,33 @@
+"""CLI entry point for aignostics-sdk slim distribution.
+
+This module wires only the platform sub-commands (user, sdk) into a trimmed
+Typer application.  It deliberately does *not* call ``prepare_cli`` because
+that function uses ``locate_implementations`` to deep-scan the ``aignostics``
+package and would pull in the heavy domain modules (application, wsi, dataset,
+bucket, qupath, …) that are absent from this slim distribution.
+"""
+
+from __future__ import annotations
+
+import typer
+
+from aignostics_sdk.platform import cli_sdk, cli_user
+from aignostics_sdk.utils import __python_version__, __version__
+from aignostics_sdk.utils._cli import _add_epilog_recursively, _no_args_is_help_recursively
+
+_EPILOG = f"🔬 Aignostics SDK v{__version__} - built with love in Berlin 🐻 // Python v{__python_version__}"
+
+cli = typer.Typer(
+    help="Command Line Interface (CLI) of Aignostics SDK providing access to Aignostics Platform.",
+)
+
+cli.add_typer(cli_user)
+cli.add_typer(cli_sdk)
+
+# Apply epilog and no-args-is-help without the auto-discovery step that
+# prepare_cli performs via locate_implementations(typer.Typer).
+_add_epilog_recursively(cli, _EPILOG)
+_no_args_is_help_recursively(cli)
+
+if __name__ == "__main__":  # pragma: no cover
+    cli()


### PR DESCRIPTION
## Release Train — PYSDK-133

> Verify wiring on the integration branch first: **#661** (draft, targets `main`)

| Step | PR | Jira | Phase | Notes |
|------|----|------|-------|-------|
| 1 | #653 | PYSDK-134 | Workspace scaffolding | **Merge first — gates everything below** |
| 2a | #656 | PYSDK-135 | Source migration | After #653 |
| 2b | #655 | PYSDK-138 | Dependency split | After #653, parallel with 2a |
| 2c | #654 | PYSDK-139 | Tooling updates | After #653, parallel with 2a |
| 3 | #657 | PYSDK-136 | Import rewrite | After #656 |
| 4a | #658 | PYSDK-137 | Slim CLI | After #657 |
| 4b | #659 | PYSDK-141 | Tests | After #657, parallel with 4a |
| ∞ | #651 | PYSDK-140 | CI/CD pipeline | Independent — merge any time |
| ∞ | #652 | PYSDK-142 | Docs & migration | Independent — merge any time |

> **Retargeting**: each PR currently targets its predecessor branch. After the predecessor merges into `feat/PYSDK-133/python-sdk-slim`, retarget this PR to `feat/PYSDK-133/python-sdk-slim` before merging it.

---

> **This PR — Step 4a**: Merge after #657 (import rewrite), parallel with #659. Retarget to `feat/PYSDK-133/python-sdk-slim` first.

## Summary

- Adds `packages/aignostics-sdk/src/aignostics_sdk/cli.py` — the entry point for the `aignostics-sdk` slim distribution CLI (wired via `aignostics-sdk = "aignostics_sdk.cli:cli"` in `pyproject.toml`)
- Exposes only the platform sub-commands: `user` (login, logout, whoami) and `sdk` (run-metadata-schema, item-metadata-schema)
- Deliberately skips `prepare_cli()` auto-discovery to prevent the heavy domain modules (application, wsi, dataset, bucket, qupath, system) from being pulled in via `locate_implementations(typer.Typer)` which deep-scans the `aignostics` package

## `aignostics-sdk --help` output

```
Usage: aignostics-sdk [OPTIONS] COMMAND [ARGS]...

 Command Line Interface (CLI) of Aignostics SDK providing access to Aignostics
 Platform.

╭─ Options ──────────────────────────────────────────────────────────────────╮
│ --install-completion          Install completion for the current shell.    │
│ --show-completion             Show completion for the current shell.       │
│ --help                        Show this message and exit.                  │
╰────────────────────────────────────────────────────────────────────────────╯
╭─ Commands ─────────────────────────────────────────────────────────────────╮
│ user  User operations such as login, logout and whoami.                    │
│ sdk   Platform operations such as dumping the SDK metadata schema.         │
╰────────────────────────────────────────────────────────────────────────────╯

 🔬 Aignostics SDK v1.4.0 - built with love in Berlin 🐻 // Python v3.14.3
```

**Included commands:** `user login`, `user logout`, `user whoami`, `sdk run-metadata-schema`, `sdk item-metadata-schema`

**Excluded commands:** `application`, `wsi`, `dataset`, `bucket`, `qupath`, `notebook`, `gui`, `system`, `launchpad`, `mcp`

## Why not `prepare_cli()`?

`prepare_cli()` calls `locate_implementations(typer.Typer)` which deep-scans the package named `__project_name__` (hardcoded as `"aignostics"`). In the monorepo workspace — and in any installation where the full `aignostics` package is present — this would silently add all heavy domain CLIs, defeating the purpose of the slim distribution. The fix is to apply only the UX helpers (`_add_epilog_recursively`, `_no_args_is_help_recursively`) directly, without the auto-discovery step.

## Test plan

- [x] `uv run --package aignostics-sdk aignostics-sdk --help` shows only `user` and `sdk` commands
- [x] `uv run --package aignostics-sdk aignostics-sdk user --help` shows login/logout/whoami
- [x] `uv run --package aignostics-sdk aignostics-sdk sdk --help` shows metadata-schema commands
- [x] `make lint` passes (ruff + pyright + mypy)
- [x] No heavy module commands (`application`, `wsi`, `dataset`, `bucket`, `qupath`, `notebook`, `gui`, `system`, `launchpad`) appear in help output