### PR TITLE
test: add slim smoke tests and verify test suite for aignostics-sdk split [PYSDK-141]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,7 @@ markers = [
     "unit: Solitary unit tests - test a layer of a module in isolation with all dependencies mocked, except interaction with shared utils and the systems module. Unit tests must be able to pass offline, i.e. not calls to external services. The timeout should not be bigger than the default 10s, and must be <5 min.",
     "integration: Sociable integration tests - test interactions across architectural layers (e.g. CLI/GUI→Service, Service→Utils) or between modules (e.g. Application→Platform), using real SDK collaborators, real file I/O, real subprocesses, and real Docker containers. Integration test must be able to pass offline, i.e. mock external services (Aignostics Platform API, Auth0, S3/GCS buckets, IDC). The timeout should not be bigger than the default 10s, and must be <5 min.",
     "e2e: End-to-end tests - test complete workflows with real external network services (Aignostics Platform API, cloud storage, IDC, etc). If the test timeout is >= 5 min and < 60 min, additionally mark as `long_running`, if >= 60min mark as 'very_long_running'.",
+    "slim: Tests for the aignostics-sdk slim package distribution.",
 ]
 md_report = true
 md_report_output = "reports/pytest.md"

--- a/tests/aignostics_sdk/__init__.py
+++ b/tests/aignostics_sdk/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the aignostics-sdk slim package distribution."""

--- a/tests/aignostics_sdk/smoke_test.py
+++ b/tests/aignostics_sdk/smoke_test.py
@@ -1,0 +1,92 @@
+"""Smoke tests for the aignostics-sdk slim package.
+
+These tests verify the slim distribution works in isolation:
+- Correct imports resolve
+- Core constants are accessible
+
+Note: The aignostics-sdk CLI entry point (aignostics_sdk.cli) is pending
+PYSDK-137 (CLI carve-out). The test_slim_cli_entry_point test is marked
+xfail until that phase lands.
+
+Note: Dependency slimming (removal of heavy deps such as openslide, nicegui,
+etc.) is pending PYSDK-138 (dependency split). Until that phase merges,
+aignostics-sdk carries the full dependency tree.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.unit
+@pytest.mark.slim
+def test_platform_client_importable() -> None:
+    """Core import from aignostics_sdk.platform works."""
+    from aignostics_sdk.platform import Client
+
+    assert Client is not None
+
+
+@pytest.mark.unit
+@pytest.mark.slim
+def test_utils_importable() -> None:
+    """Core imports from aignostics_sdk.utils work."""
+    from aignostics_sdk.utils import BaseService, Health
+
+    assert BaseService is not None
+    assert Health is not None
+
+
+@pytest.mark.unit
+@pytest.mark.slim
+def test_aignx_codegen_importable() -> None:
+    """Bundled codegen is accessible."""
+    from aignx.codegen.exceptions import ApiException
+
+    assert ApiException is not None
+
+
+@pytest.mark.unit
+@pytest.mark.slim
+@pytest.mark.xfail(
+    reason="aignostics_sdk.cli module does not exist yet — pending PYSDK-137 (CLI carve-out)",
+    strict=True,
+)
+def test_slim_cli_entry_point() -> None:
+    """aignostics-sdk CLI entry point exits 0.
+
+    This test is xfail until PYSDK-137 creates the aignostics_sdk.cli module
+    that aggregates the slim subcommands (user, sdk).
+    """
+    result = subprocess.run(
+        [sys.executable, "-m", "aignostics_sdk.cli", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "user" in result.stdout
+    assert "sdk" in result.stdout
+
+
+@pytest.mark.unit
+@pytest.mark.slim
+def test_project_name_preserved() -> None:
+    """__project_name__ is 'aignostics' for backward compat (env vars, token cache)."""
+    from aignostics_sdk.utils._constants import __project_name__
+
+    assert __project_name__ == "aignostics"
+
+
+@pytest.mark.unit
+@pytest.mark.slim
+def test_version_available() -> None:
+    """Package version is accessible."""
+    from aignostics_sdk.utils._constants import __version__
+
+    assert __version__ is not None
+    assert len(__version__) > 0


### PR DESCRIPTION
## Release Train — PYSDK-133

> Verify wiring on the integration branch first: **#661** (draft, targets `main`)

| Step | PR | Jira | Phase | Notes |
|------|----|------|-------|-------|
| 1 | #653 | PYSDK-134 | Workspace scaffolding | **Merge first — gates everything below** |
| 2a | #656 | PYSDK-135 | Source migration | After #653 |
| 2b | #655 | PYSDK-138 | Dependency split | After #653, parallel with 2a |
| 2c | #654 | PYSDK-139 | Tooling updates | After #653, parallel with 2a |
| 3 | #657 | PYSDK-136 | Import rewrite | After #656 |
| 4a | #658 | PYSDK-137 | Slim CLI | After #657 |
| 4b | #659 | PYSDK-141 | Tests | After #657, parallel with 4a |
| ∞ | #651 | PYSDK-140 | CI/CD pipeline | Independent — merge any time |
| ∞ | #652 | PYSDK-142 | Docs & migration | Independent — merge any time |

> **Retargeting**: each PR currently targets its predecessor branch. After the predecessor merges into `feat/PYSDK-133/python-sdk-slim`, retarget this PR to `feat/PYSDK-133/python-sdk-slim` before merging it.

---

> **This PR — Step 4b**: Merge after #657 (import rewrite), parallel with #658. Retarget to `feat/PYSDK-133/python-sdk-slim` first.

## Summary

- Registers the `slim` pytest marker in `pyproject.toml` for tests targeting the `aignostics-sdk` slim package distribution
- Creates `tests/aignostics_sdk/__init__.py` and `tests/aignostics_sdk/smoke_test.py` with 6 tests (5 passing, 1 xfail)
- Verifies test collection is clean: 904 tests collected, 0 collection errors, no stale `from aignostics.platform` / `from aignostics.utils` imports in test files

## Smoke test coverage

| Test | Result | Notes |
|---|---|---|
| `test_platform_client_importable` | PASS | `aignostics_sdk.platform.Client` resolves |
| `test_utils_importable` | PASS | `aignostics_sdk.utils.{BaseService,Health}` resolve |
| `test_aignx_codegen_importable` | PASS | `aignx.codegen.exceptions.ApiException` resolves |
| `test_project_name_preserved` | PASS | `__project_name__ == "aignostics"` for backward compat |
| `test_version_available` | PASS | `__version__` is non-empty |
| `test_slim_cli_entry_point` | XFAIL (strict) | `aignostics_sdk.cli` module pending **PYSDK-137** |

## Known pre-existing failures (not introduced here)

The base branch `feat/PYSDK-136/import-rewrite` already has 116 failing unit tests and 93 errors from stale `patch("aignostics.platform._authentication...")` and similar mock paths that were not updated when PYSDK-136 rewrote the `from aignostics.*` imports. These will be addressed in a follow-up fix to PYSDK-136 and are not in scope for this PR.

## Deferred work

- **PYSDK-137**: `aignostics_sdk.cli` module carve-out — `test_slim_cli_entry_point` will flip from xfail to green once that lands
- **PYSDK-138**: Dependency slimming — heavy deps (`openslide`, `nicegui`, etc.) are still present in `aignostics-sdk`; the "heavy deps not present" assertions from the original task spec are deferred until PYSDK-138 merges

---

*This PR was created by Claude (claude-sonnet-4-6) on behalf of Ari Angelo (ari@aignostics.com).*