### PR TITLE
fix(deps): set rangeStrategy widen for all pep621 packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,11 @@
   },
   "packageRules": [
     {
+      "description": "Widen version ranges for pep621 packages rather than replacing them, preserving backward compatibility with older installed versions",
+      "matchManagers": ["pep621"],
+      "rangeStrategy": "widen"
+    },
+    {
       "description": "Runtime-critical packages whose bumps touch the GUI event loop, HTTP client, or pydantic models — regressions in these only surface end-to-end (closure lifecycles, event handler exception swallowing, request retry semantics, ...). Override the global labels to drop `skip:test:long_running` so the long-running e2e matrix runs and catches integration regressions on every bump. Discovered while shipping nicegui 3.10/3.11 (#531) where a silently-swallowed AssertionError inside an async click handler hung a download dialog and was only caught by the long-running suite.",
       "matchPackageNames": [
         "nicegui",


### PR DESCRIPTION
**Why?**
Renovate was generating bump PRs (e.g. `>=23.0.1,<24` → `>=25,<26` for pyarrow, `>=1.19.0,<2` → `>=2.3,<3` for mypy) instead of widening the existing range. For a published SDK, bumping discards backward compatibility with older installed versions that users may have pinned.

**How?**
Adds a `packageRule` scoped to the `pep621` manager with `rangeStrategy: widen`, covering all update types including major. Renovate will now extend the upper bound of existing ranges rather than replacing them (e.g. `>=23.0.1,<26` instead of `>=25,<26`). PRs #697 and #648 can be rebased to pick up the corrected behaviour.