### PR TITLE
ci: run very-long-running e2e on manual dispatch to release branches

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -87,7 +87,8 @@ if any category failed.
 | e2e very long running | `test_very_long_running` | (opt-in, see below) |
 
 **Very long running** runs only when enabled: `enable:test:very_long_running`
-in commit message or PR label, or any push to a `release/v*` branch.
+in commit message or PR label, or any push or manual dispatch
+(`workflow_dispatch`) to a `release/v*` branch.
 
 **Parallelism** is set by `XDIST_WORKER_FACTOR` (worker count =
 `max(1, int(cpu_count * factor))`). CI runs the `*_matrix` targets — unit and

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -220,7 +220,7 @@ jobs:
           !cancelled() && (
             contains(inputs.commit_message, 'enable:test:very_long_running') ||
             contains(github.event.pull_request.labels.*.name, 'enable:test:very_long_running') ||
-            (github.event_name == 'push' && startsWith(github.ref, 'refs/heads/release/v'))
+            ((github.event_name == 'push' || github.event_name == 'workflow_dispatch') && startsWith(github.ref, 'refs/heads/release/v'))
           )
         uses: ./.github/actions/run-tests
         with:


### PR DESCRIPTION
**Why?**
Manually triggering the CI/CD workflow (`workflow_dispatch`) against a `release/v*` branch did not run the very-long-running e2e suite ([example run](https://github.com/aignostics/python-sdk/actions/runs/31502215475/job/93814967519)), even though a normal `push` to the same branch does. The gate only matched `push` events, so manual release validation silently skipped these tests.

**How?**
Broaden the gate in `.github/workflows/_test.yml` to also accept `github.event_name == 'workflow_dispatch'` while keeping the `refs/heads/release/v*` ref guard, so manual dispatch against a release branch behaves like a push but dispatches against `main`/feature branches still require the `enable:test:very_long_running` marker. `.github/CLAUDE.md` is updated to document the new trigger.