### PR TITLE
fix(ci): fix daily Sentry monitor slug and move crons off minute 0

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -21,11 +21,11 @@ workflows (`> …`, prefixed `_`) are called via `uses:`.
 | `claude-code-interactive.yml` | `@claude` mentions + workflow_dispatch | `_claude-code` (interactive) |
 | `claude-code-automation-pr-review.yml` | PR with `claude` label or `ready_for_review` | `_claude-code` (automation) |
 | `claude-code-automation-operational-excellence-weekly.yml` | schedule + workflow_dispatch | `_claude-code` (automation) |
-| `scheduled-testing-staging-hourly.yml` | cron `0 * * * *` | `_scheduled-test-hourly` (staging) |
-| `scheduled-testing-staging-daily.yml` | cron `0 12 * * *` | `_scheduled-test-daily` (staging) |
-| `scheduled-testing-production-hourly.yml` | cron `0 * * * *` | `_scheduled-test-hourly` (production) |
-| `scheduled-testing-production-daily.yml` | cron `0 12 * * *` | `_scheduled-test-daily` (production) |
-| `scheduled-audit-hourly.yml` | cron `0 * * * *` | `_scheduled-audit` |
+| `scheduled-testing-staging-hourly.yml` | cron `17 * * * *` | `_scheduled-test-hourly` (staging) |
+| `scheduled-testing-staging-daily.yml` | cron `31 12 * * *` | `_scheduled-test-daily` (staging) |
+| `scheduled-testing-production-hourly.yml` | cron `17 * * * *` | `_scheduled-test-hourly` (production) |
+| `scheduled-testing-production-daily.yml` | cron `31 12 * * *` | `_scheduled-test-daily` (production) |
+| `scheduled-audit-hourly.yml` | cron `43 * * * *` | `_scheduled-audit` |
 | `codeql-scheduled.yml` | cron `22 3 * * 2` (Tue 03:22) | `_codeql` |
 | `labels-sync.yml` | push to label config | — |
 
@@ -148,10 +148,11 @@ or GCP credentials.
 
 ## Scheduled jobs
 
-- **Testing** — staging and production each run **hourly** (`0 * * * *`, via
-  `_scheduled-test-hourly.yml`) and **daily at 12:00 UTC** (`0 12 * * *`, via
-  `_scheduled-test-daily.yml`). Run `make test_scheduled`, send a BetterStack
-  heartbeat. Staging → `https://platform-staging.aignostics.com`, production →
+- **Testing** — staging and production each run **hourly** (`17 * * * *`, via
+  `_scheduled-test-hourly.yml`) and **daily at 12:31 UTC** (`31 12 * * *`, via
+  `_scheduled-test-daily.yml`). The crons avoid minute 0: GitHub documents
+  that `schedule` events are delayed most at the start of every hour. Run
+  `make test_scheduled`, send a BetterStack heartbeat. Staging → `https://platform-staging.aignostics.com`, production →
   `https://platform.aignostics.com`.
 - **Audit** — hourly (`_scheduled-audit.yml`): `pip-audit`, `pip-licenses`,
   Trivy SBOM scan + BetterStack heartbeat.

--- a/.github/workflows/_scheduled-test-daily.yml
+++ b/.github/workflows/_scheduled-test-daily.yml
@@ -260,7 +260,7 @@ jobs:
           FAILED_TESTS="${{ steps.test-status.outputs.failed_tests }}"
           
           # Send heartbeat to Sentry, defining the schedule on the fly
-          SENTRY_EXIT_CODE=$(sentry-cli monitors run -e CI --schedule "0 12 * * *" --check-in-margin 30 --max-runtime 1 scheduled-testing-${{ inputs.platform_environment }}-daily --timezone "Europe/Berlin" -- sh -c "exit $EXIT_CODE")
+          SENTRY_EXIT_CODE=$(sentry-cli monitors run -e CI --schedule "31 12 * * *" --check-in-margin 60 --max-runtime 1 scheduled-testing-${{ inputs.platform_environment }}-daily --timezone "Europe/Berlin" -- sh -c "exit $EXIT_CODE")
 
           # Provide heartbeat to BetterStack for monitoring/alerting if heartbeat url is configured as secret
           if [ -n "$BETTERSTACK_HEARTBEAT_URL" ]; then

--- a/.github/workflows/_scheduled-test-daily.yml
+++ b/.github/workflows/_scheduled-test-daily.yml
@@ -260,7 +260,7 @@ jobs:
           FAILED_TESTS="${{ steps.test-status.outputs.failed_tests }}"
           
           # Send heartbeat to Sentry, defining the schedule on the fly
-          SENTRY_EXIT_CODE=$(sentry-cli monitors run -e CI --schedule "0 12 * * *" --check-in-margin 30 --max-runtime 1 scheduled-testing-${{ inputs.platform_environment }}-hourly --timezone "Europe/Berlin" -- sh -c "exit $EXIT_CODE")
+          SENTRY_EXIT_CODE=$(sentry-cli monitors run -e CI --schedule "0 12 * * *" --check-in-margin 30 --max-runtime 1 scheduled-testing-${{ inputs.platform_environment }}-daily --timezone "Europe/Berlin" -- sh -c "exit $EXIT_CODE")
 
           # Provide heartbeat to BetterStack for monitoring/alerting if heartbeat url is configured as secret
           if [ -n "$BETTERSTACK_HEARTBEAT_URL" ]; then

--- a/.github/workflows/_scheduled-test-hourly.yml
+++ b/.github/workflows/_scheduled-test-hourly.yml
@@ -122,7 +122,7 @@ jobs:
           fi
 
           # Send heartbeat to Sentry, defining the schedule on the fly
-          SENTRY_EXIT_CODE=$(sentry-cli monitors run -e CI --schedule "0 * * * *" --check-in-margin 30 --max-runtime 1 scheduled-testing-${{ inputs.platform_environment }}-hourly --timezone "Europe/Berlin" -- sh -c "exit $EXIT_CODE")
+          SENTRY_EXIT_CODE=$(sentry-cli monitors run -e CI --schedule "17 * * * *" --check-in-margin 60 --max-runtime 1 scheduled-testing-${{ inputs.platform_environment }}-hourly --timezone "Europe/Berlin" -- sh -c "exit $EXIT_CODE")
 
           # Provide heartbeat to BetterStack for monitoring/alerting if heartbeat url is configured as secret
           if [ -n "$BETTERSTACK_HEARTBEAT_URL" ]; then

--- a/.github/workflows/scheduled-audit-hourly.yml
+++ b/.github/workflows/scheduled-audit-hourly.yml
@@ -2,7 +2,7 @@ name: "+ Scheduled Audit (Hourly)"
 
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '43 * * * *'
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/scheduled-testing-production-daily.yml
+++ b/.github/workflows/scheduled-testing-production-daily.yml
@@ -2,7 +2,7 @@ name: "+ Scheduled Testing / Production (Daily)"
 
 on:
   schedule:
-    - cron: '0 12 * * *'
+    - cron: '31 12 * * *'
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/scheduled-testing-production-hourly.yml
+++ b/.github/workflows/scheduled-testing-production-hourly.yml
@@ -2,7 +2,7 @@ name: "+ Scheduled Testing / Production (Hourly)"
 
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '17 * * * *'
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/scheduled-testing-staging-daily.yml
+++ b/.github/workflows/scheduled-testing-staging-daily.yml
@@ -2,7 +2,7 @@ name: "+ Scheduled Testing / Staging (Daily)"
 
 on:
   schedule:
-    - cron: '0 12 * * *'
+    - cron: '31 12 * * *'
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/scheduled-testing-staging-hourly.yml
+++ b/.github/workflows/scheduled-testing-staging-hourly.yml
@@ -2,7 +2,7 @@ name: "+ Scheduled Testing / Staging (Hourly)"
 
 on:
   schedule:
-    - cron: '0 * * * *'
+    - cron: '17 * * * *'
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
**Why?**
The scheduled-test monitoring raises false alerts for two reasons. (1) The daily workflow checks in to the Sentry cron monitor `scheduled-testing-<env>-hourly` with schedule `0 12 * * *`, so each daily run overwrites the hourly monitor's schedule and the daily tests have no monitor of their own. (2) All scheduled crons fire at minute 0, which GitHub documents as the peak-load time when `schedule` events are delayed most; a 30-minute Sentry check-in margin then alerts on normal jitter.

**How?**
Change the daily monitor slug to `scheduled-testing-<env>-daily` (`sentry-cli monitors run` creates it on first check-in). Move the hourly test crons to minute 17, the daily test crons to 12:31 UTC, and the audit cron to minute 43; align the Sentry `--schedule` strings and raise `--check-in-margin` to 60. Update the schedule table and prose in `.github/CLAUDE.md`.

**After merge (todo)**
- [ ] BetterStack: set the heartbeat period/grace of the hourly test monitors (staging, production) and the audit monitor to tolerate at least 60 minutes of delay, and move the daily monitors to 12:31 UTC.
- [ ] Sentry: confirm the new `scheduled-testing-<env>-daily` monitors appear after the first daily run and that the `-hourly` monitors show schedule `17 * * * *`.